### PR TITLE
feat: improve validation error display

### DIFF
--- a/src/i18n/resources/en.tsx
+++ b/src/i18n/resources/en.tsx
@@ -400,5 +400,7 @@ export const translations: Translations<'en'> = {
     'unknownError.subtitle': 'An unexpected error occurred.',
     'unknownError.paragraph':
       'Please try again later or contact the site administrator for assistance.',
+    'validationError.title': 'Validation Error',
+    'validationError.subtitle': ({ name }) => `${name}'s file is not valid.`,
   },
 }

--- a/src/i18n/resources/fr.tsx
+++ b/src/i18n/resources/fr.tsx
@@ -418,5 +418,8 @@ export const translations: Translations<'fr'> = {
     'unknownError.subtitle': "Une erreur inattendue s'est produite.",
     'unknownError.paragraph':
       "Veuillez réessayer ultérieurement ou contacter l'administrateur du site pour obtenir de l'aide.",
+    'validationError.title': 'Erreur de validation',
+    'validationError.subtitle': ({ name }) =>
+      `Le fichier de ${name} n'est pas valide.`,
   },
 }

--- a/src/i18n/resources/sq.tsx
+++ b/src/i18n/resources/sq.tsx
@@ -408,5 +408,8 @@ export const translations: Translations<'sq'> = {
     'unknownError.subtitle': 'Ndodhi një gabim i papritur.',
     'unknownError.paragraph':
       'Ju lutem provoni më vonë ose kontaktoni administratorin e faqes për ndihmë.',
+    'validationError.title': 'Gabim i vlefshmërisë',
+    'validationError.subtitle': ({ name }) =>
+      `Skedari i ${name} nuk është i vlefshëm.`,
   },
 }

--- a/src/shared/error/ZodErrorWithName.ts
+++ b/src/shared/error/ZodErrorWithName.ts
@@ -1,0 +1,12 @@
+import { ZodError, type ZodIssue } from 'zod'
+
+export type ZodErrorName = 'metadata'
+
+export class ZodErrorWithName extends ZodError {
+  name: ZodErrorName
+
+  constructor(issues: ZodIssue[], name: ZodErrorName) {
+    super(issues)
+    this.name = name
+  }
+}

--- a/src/shared/parser/metadata.ts
+++ b/src/shared/parser/metadata.ts
@@ -1,5 +1,6 @@
 import type { SurveyUnitMetadata } from 'model/api'
-import { assert, type Equals } from 'tsafe/assert'
+import { assert } from 'tsafe/assert'
+import type { Extends } from 'tsafe/Extends'
 import { z } from 'zod'
 
 const logoSchema = z.object({
@@ -10,6 +11,18 @@ const logoSchema = z.object({
 const logosSchema = z.object({
   main: logoSchema,
   secondaries: z.array(logoSchema).optional(),
+})
+
+// Schema for Content
+const contentSchema = z.object({
+  type: z.enum(['paragraph', 'list']),
+  textItems: z.array(z.string()),
+})
+
+// Schema for Contents
+const contentsSchema = z.object({
+  title: z.string().optional(),
+  contentBlocks: z.array(contentSchema),
 })
 
 export const surveyUnitMetadataSchema = z.object({
@@ -25,17 +38,10 @@ export const surveyUnitMetadataSchema = z.object({
       })
     )
     .optional(),
-  variables: z
-    .array(
-      z
-        .object({
-          name: z.string(),
-          value: z.unknown(),
-        })
-        .transform(({ name, value }) => ({ name, value })) //To solve zod issue cf https://github.com/colinhacks/zod/issues/2966#issuecomment-2000436630
-    )
-    .optional(),
+  surveyUnitIdentifier: z.string().optional(),
+  surveyUnitInfo: contentsSchema.array().optional(),
+  campaignInfo: contentsSchema.array().optional(),
 })
 
 type InferredMetadata = z.infer<typeof surveyUnitMetadataSchema>
-assert<Equals<InferredMetadata, SurveyUnitMetadata>>()
+assert<Extends<InferredMetadata, SurveyUnitMetadata>>() //When SurveyUnitMetadata will change according to the new modelisation, replace Extends by Equals


### PR DESCRIPTION
This PR improves the validation error display as shown below:

![Screenshot 2024-09-04 at 09 49 24](https://github.com/user-attachments/assets/3abb7bc7-87d5-4873-9a5d-004b1d05add4)

The Zod validation errors are not currently translated. To implement translation for these errors, you can refer to this [repo](https://github.com/aiji42/zod-i18n) for guidance. Specifically, you would need to create a custom [ZodErrorMap](https://zod.dev/ERROR_HANDLING?id=customizing-errors-with-zoderrormap) using the i18n library we already use in the project, [i18nifty](https://docs.i18nifty.dev/api-reference/localizedstring).

The custom error map should utilize the [LocalizedString](https://docs.i18nifty.dev/api-reference/localizedstring) concept from the i18nifty library to manage translations dynamically and effectively.

Note: This PR does not include the implementation of translations but outlines how they can be handled in the future.