### PR TITLE
Refactor/improved husky prettier config

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-yarn test && yarn lint && yarn format:check
+yarn test && yarn lint-staged

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-node_modules/
-/.yarn_home/
-/dist/
+.yarn_home/
+src/vite-env.d.ts
 website/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,11 +1,5 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "es5",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "jsxSingleQuote": false,
-  "bracketSameLine": false,
-  "arrowParens": "always",
   "plugins": ["prettier-plugin-organize-imports"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,15 @@ import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['src/model/api/'] },
+  {
+    ignores: [
+      'dist',
+      // generated files
+      'src/api/[0-9][0-9]-*.ts',
+      'src/model/api/',
+      'src/vite-env.d.ts',
+    ],
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['src/**/*.{ts,tsx}'],
@@ -23,7 +31,10 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       // see https://typescript-eslint.netlify.app/rules/no-unused-vars/
-      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_$" }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        { argsIgnorePattern: '^_$' },
+      ],
       '@typescript-eslint/no-explicit-any': ['off'],
       '@typescript-eslint/no-namespace': ['off'],
       'react-refresh/only-export-components': [
@@ -31,5 +42,5 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
     },
-  }
+  },
 )

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Marianne-Bold_Italic.woff2" as="font" crossorigin="anonymous" />-->
     <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Spectral-Regular.woff2" as="font" crossorigin="anonymous" />-->
     <!--<link rel="preload" href="./node_modules/@codegouvfr/react-dsfr/dsfr/fonts/Spectral-ExtraBold.woff2" as="font" crossorigin="anonymous" />-->
-    
+
     <!-- End DSFR -->
   </head>
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "tsc && vite build",
     "lint": "eslint ./src",
     "preview": "vite preview",
-    "_format": "prettier '**/*.{ts,tsx,json,md}'",
+    "_format": "prettier --ignore-unknown .",
     "format": "npm run _format -- --write",
     "format:check": "npm run _format -- --list-different",
     "predev": "react-dsfr update-icons",
@@ -61,6 +61,7 @@
     "globals": "^15.9.0",
     "husky": "^9.1.6",
     "jsdom": "^25.0.1",
+    "lint-staged": "^15.2.10",
     "orval": "^7.0.1",
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.0.0",
@@ -71,5 +72,12 @@
     "vite-envs": "^4.4.5",
     "vite-tsconfig-paths": "^5.0.1",
     "vitest": "^2.1.2"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write --list-different"
+    ],
+    "!(*.js|*.jsx|*.ts|*.tsx)": "prettier --write --ignore-unknown --list-different"
   }
 }

--- a/public/silent-sso.htm
+++ b/public/silent-sso.htm
@@ -1,7 +1,7 @@
 <html>
-    <body>
-        <script>
-            parent.postMessage(location.href, location.origin);
-        </script>
-    </body>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin)
+    </script>
+  </body>
 </html>

--- a/scripts/generate-api-client.ts
+++ b/scripts/generate-api-client.ts
@@ -22,7 +22,7 @@ async function main() {
 
     const updatedConfigContent = createModifiedOrvalConfigContent(
       ORIGINAL_ORVAL_CONFIG_PATH,
-      mainOpenApiFilePath
+      mainOpenApiFilePath,
     )
 
     writeOrvalConfig(cachedOrvalConfigPath, updatedConfigContent)
@@ -61,7 +61,7 @@ async function fetchAndCacheOpenApiSpec(url: string): Promise<string> {
 // Create modified orval.config.ts content
 function createModifiedOrvalConfigContent(
   originalConfigPath: string,
-  openApiFilePath: string
+  openApiFilePath: string,
 ): string {
   console.log('Creating modified orval.config.ts content...')
   const configContent = readFileSync(originalConfigPath, 'utf-8')

--- a/src/api/01-integrations.ts
+++ b/src/api/01-integrations.ts
@@ -27,7 +27,7 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  */
 export const integrateXmlContext = (
   integrateXmlContextBody: IntegrateXmlContextBody,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   const formData = new FormData()
   formData.append('file', integrateXmlContextBody.file)
@@ -39,7 +39,7 @@ export const integrateXmlContext = (
       headers: { 'Content-Type': 'multipart/form-data' },
       data: formData,
     },
-    options
+    options,
   )
 }
 
@@ -111,7 +111,7 @@ export const useIntegrateXmlContext = <
  */
 export const integrateContext = (
   integrateContextBody: IntegrateContextBody,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   const formData = new FormData()
   formData.append('file', integrateContextBody.file)
@@ -123,7 +123,7 @@ export const integrateContext = (
       headers: { 'Content-Type': 'multipart/form-data' },
       data: formData,
     },
-    options
+    options,
   )
 }
 

--- a/src/api/02-campaigns.ts
+++ b/src/api/02-campaigns.ts
@@ -34,11 +34,11 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  */
 export const getInterviewerCampaignList = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<CampaignSummary[]>(
     { url: `/api/campaigns`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -170,7 +170,7 @@ export function useGetInterviewerCampaignList<
  */
 export const createCampaign = (
   campaignCreation: CampaignCreation,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -179,7 +179,7 @@ export const createCampaign = (
       headers: { 'Content-Type': 'application/json' },
       data: campaignCreation,
     },
-    options
+    options,
   )
 }
 
@@ -251,7 +251,7 @@ export const useCreateCampaign = <
  */
 export const createCampaignV2 = (
   campaignCreationV2: CampaignCreationV2,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -260,7 +260,7 @@ export const createCampaignV2 = (
       headers: { 'Content-Type': 'application/json' },
       data: campaignCreationV2,
     },
-    options
+    options,
   )
 }
 
@@ -331,11 +331,11 @@ export const useCreateCampaignV2 = <
  */
 export const getListCampaign = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<CampaignSummary[]>(
     { url: `/api/admin/campaigns`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -446,11 +446,11 @@ export function useGetListCampaign<
 export const deleteCampaignById = (
   id: string,
   params: DeleteCampaignByIdParams,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     { url: `/api/campaign/${id}`, method: 'DELETE', params },
-    options
+    options,
   )
 }
 

--- a/src/api/03-questionnaires.ts
+++ b/src/api/03-questionnaires.ts
@@ -35,7 +35,7 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  */
 export const getQuestionnaireModelIdBySurveyUnits = (
   getQuestionnaireModelIdBySurveyUnitsBody: string[],
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<SurveyUnitsOkNok>(
     {
@@ -44,7 +44,7 @@ export const getQuestionnaireModelIdBySurveyUnits = (
       headers: { 'Content-Type': 'application/json' },
       data: getQuestionnaireModelIdBySurveyUnitsBody,
     },
-    options
+    options,
   )
 }
 
@@ -116,7 +116,7 @@ export const useGetQuestionnaireModelIdBySurveyUnits = <
  */
 export const createQuestionnaire = (
   questionnaireModelCreation: QuestionnaireModelCreation,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -125,7 +125,7 @@ export const createQuestionnaire = (
       headers: { 'Content-Type': 'application/json' },
       data: questionnaireModelCreation,
     },
-    options
+    options,
   )
 }
 
@@ -198,11 +198,11 @@ export const useCreateQuestionnaire = <
 export const getQuestionnaireValue = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<QuestionnaireModelValue>(
     { url: `/api/questionnaire/${id}`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -224,7 +224,7 @@ export const getGetQuestionnaireValueQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -274,7 +274,7 @@ export function useGetQuestionnaireValue<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireValue<
   TData = Awaited<ReturnType<typeof getQuestionnaireValue>>,
@@ -298,7 +298,7 @@ export function useGetQuestionnaireValue<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireValue<
   TData = Awaited<ReturnType<typeof getQuestionnaireValue>>,
@@ -314,7 +314,7 @@ export function useGetQuestionnaireValue<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @deprecated
@@ -335,7 +335,7 @@ export function useGetQuestionnaireValue<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetQuestionnaireValueQueryOptions(id, options)
 
@@ -355,11 +355,11 @@ export function useGetQuestionnaireValue<
 export const getQuestionnaireData = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<GetQuestionnaireData200>(
     { url: `/api/questionnaire/${id}/data`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -381,7 +381,7 @@ export const getGetQuestionnaireDataQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -430,7 +430,7 @@ export function useGetQuestionnaireData<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireData<
   TData = Awaited<ReturnType<typeof getQuestionnaireData>>,
@@ -454,7 +454,7 @@ export function useGetQuestionnaireData<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireData<
   TData = Awaited<ReturnType<typeof getQuestionnaireData>>,
@@ -470,7 +470,7 @@ export function useGetQuestionnaireData<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get questionnnaire data
@@ -490,7 +490,7 @@ export function useGetQuestionnaireData<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetQuestionnaireDataQueryOptions(id, options)
 
@@ -510,11 +510,11 @@ export function useGetQuestionnaireData<
 export const getQuestionnaireDatasByCampaignId = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<QuestionnaireModelValue[]>(
     { url: `/api/campaign/${id}/questionnaires`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -536,7 +536,7 @@ export const getGetQuestionnaireDatasByCampaignIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -587,7 +587,7 @@ export function useGetQuestionnaireDatasByCampaignId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireDatasByCampaignId<
   TData = Awaited<ReturnType<typeof getQuestionnaireDatasByCampaignId>>,
@@ -611,7 +611,7 @@ export function useGetQuestionnaireDatasByCampaignId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireDatasByCampaignId<
   TData = Awaited<ReturnType<typeof getQuestionnaireDatasByCampaignId>>,
@@ -627,7 +627,7 @@ export function useGetQuestionnaireDatasByCampaignId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get questionnaire list for a campaign
@@ -647,11 +647,11 @@ export function useGetQuestionnaireDatasByCampaignId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetQuestionnaireDatasByCampaignIdQueryOptions(
     id,
-    options
+    options,
   )
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -670,11 +670,11 @@ export function useGetQuestionnaireDatasByCampaignId<
 export const getQuestionnaireIdsByCampaignId = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<QuestionnaireModelId[]>(
     { url: `/api/campaign/${id}/questionnaire-id`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -696,7 +696,7 @@ export const getGetQuestionnaireIdsByCampaignIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -747,7 +747,7 @@ export function useGetQuestionnaireIdsByCampaignId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireIdsByCampaignId<
   TData = Awaited<ReturnType<typeof getQuestionnaireIdsByCampaignId>>,
@@ -771,7 +771,7 @@ export function useGetQuestionnaireIdsByCampaignId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetQuestionnaireIdsByCampaignId<
   TData = Awaited<ReturnType<typeof getQuestionnaireIdsByCampaignId>>,
@@ -787,7 +787,7 @@ export function useGetQuestionnaireIdsByCampaignId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get list of questionnaire ids for a campaign
@@ -807,11 +807,11 @@ export function useGetQuestionnaireIdsByCampaignId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetQuestionnaireIdsByCampaignIdQueryOptions(
     id,
-    options
+    options,
   )
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {

--- a/src/api/04-nomenclatures.ts
+++ b/src/api/04-nomenclatures.ts
@@ -30,7 +30,7 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  */
 export const postNomenclature = (
   nomenclatureCreation: NomenclatureCreation,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -39,7 +39,7 @@ export const postNomenclature = (
       headers: { 'Content-Type': 'application/json' },
       data: nomenclatureCreation,
     },
-    options
+    options,
   )
 }
 
@@ -111,7 +111,7 @@ export const usePostNomenclature = <
 export const getListRequiredNomenclatureByQuestionnaireId = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<string[]>(
     {
@@ -119,12 +119,12 @@ export const getListRequiredNomenclatureByQuestionnaireId = (
       method: 'GET',
       signal,
     },
-    options
+    options,
   )
 }
 
 export const getGetListRequiredNomenclatureByQuestionnaireIdQueryKey = (
-  id: string
+  id: string,
 ) => {
   return [`/api/questionnaire/${id}/required-nomenclatures`] as const
 }
@@ -147,7 +147,7 @@ export const getGetListRequiredNomenclatureByQuestionnaireIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -206,7 +206,7 @@ export function useGetListRequiredNomenclatureByQuestionnaireId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetListRequiredNomenclatureByQuestionnaireId<
   TData = Awaited<
@@ -236,7 +236,7 @@ export function useGetListRequiredNomenclatureByQuestionnaireId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetListRequiredNomenclatureByQuestionnaireId<
   TData = Awaited<
@@ -256,7 +256,7 @@ export function useGetListRequiredNomenclatureByQuestionnaireId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get list of required nomenclature for a questionnaire
@@ -280,7 +280,7 @@ export function useGetListRequiredNomenclatureByQuestionnaireId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions =
     getGetListRequiredNomenclatureByQuestionnaireIdQueryOptions(id, options)
@@ -300,11 +300,11 @@ export function useGetListRequiredNomenclatureByQuestionnaireId<
  */
 export const getNomenclaturesId = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<string[]>(
     { url: `/api/nomenclatures`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -435,11 +435,11 @@ export function useGetNomenclaturesId<
 export const getNomenclatureById = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SchemaNomenclature>(
     { url: `/api/nomenclature/${id}`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -461,7 +461,7 @@ export const getGetNomenclatureByIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -510,7 +510,7 @@ export function useGetNomenclatureById<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetNomenclatureById<
   TData = Awaited<ReturnType<typeof getNomenclatureById>>,
@@ -534,7 +534,7 @@ export function useGetNomenclatureById<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetNomenclatureById<
   TData = Awaited<ReturnType<typeof getNomenclatureById>>,
@@ -550,7 +550,7 @@ export function useGetNomenclatureById<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get Nomenclature
@@ -570,7 +570,7 @@ export function useGetNomenclatureById<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetNomenclatureByIdQueryOptions(id, options)
 
@@ -590,7 +590,7 @@ export function useGetNomenclatureById<
 export const getListRequiredNomenclature = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<string[]>(
     {
@@ -598,7 +598,7 @@ export const getListRequiredNomenclature = (
       method: 'GET',
       signal,
     },
-    options
+    options,
   )
 }
 
@@ -620,7 +620,7 @@ export const getGetListRequiredNomenclatureQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -670,7 +670,7 @@ export function useGetListRequiredNomenclature<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetListRequiredNomenclature<
   TData = Awaited<ReturnType<typeof getListRequiredNomenclature>>,
@@ -694,7 +694,7 @@ export function useGetListRequiredNomenclature<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetListRequiredNomenclature<
   TData = Awaited<ReturnType<typeof getListRequiredNomenclature>>,
@@ -710,7 +710,7 @@ export function useGetListRequiredNomenclature<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get list of required nomenclatures for a campaign
@@ -730,7 +730,7 @@ export function useGetListRequiredNomenclature<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetListRequiredNomenclatureQueryOptions(id, options)
 

--- a/src/api/05-metadata.ts
+++ b/src/api/05-metadata.ts
@@ -27,11 +27,11 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
 export const getMetadataByQuestionnaireId = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SchemaMetadata>(
     { url: `/api/questionnaire/${id}/metadata`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -53,7 +53,7 @@ export const getGetMetadataByQuestionnaireIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -103,7 +103,7 @@ export function useGetMetadataByQuestionnaireId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetMetadataByQuestionnaireId<
   TData = Awaited<ReturnType<typeof getMetadataByQuestionnaireId>>,
@@ -127,7 +127,7 @@ export function useGetMetadataByQuestionnaireId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetMetadataByQuestionnaireId<
   TData = Awaited<ReturnType<typeof getMetadataByQuestionnaireId>>,
@@ -143,7 +143,7 @@ export function useGetMetadataByQuestionnaireId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get metadata for a questionnaire
@@ -163,7 +163,7 @@ export function useGetMetadataByQuestionnaireId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetMetadataByQuestionnaireIdQueryOptions(id, options)
 
@@ -183,11 +183,11 @@ export function useGetMetadataByQuestionnaireId<
 export const getMetadataByCampaignId = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SchemaMetadata>(
     { url: `/api/campaign/${id}/metadata`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -209,7 +209,7 @@ export const getGetMetadataByCampaignIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -259,7 +259,7 @@ export function useGetMetadataByCampaignId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetMetadataByCampaignId<
   TData = Awaited<ReturnType<typeof getMetadataByCampaignId>>,
@@ -283,7 +283,7 @@ export function useGetMetadataByCampaignId<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetMetadataByCampaignId<
   TData = Awaited<ReturnType<typeof getMetadataByCampaignId>>,
@@ -299,7 +299,7 @@ export function useGetMetadataByCampaignId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get metadata for a campaign
@@ -319,7 +319,7 @@ export function useGetMetadataByCampaignId<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetMetadataByCampaignIdQueryOptions(id, options)
 

--- a/src/api/06-survey-units.ts
+++ b/src/api/06-survey-units.ts
@@ -44,11 +44,11 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
 export const getSurveyUnitById = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SurveyUnit>(
     { url: `/api/survey-unit/${id}`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -70,7 +70,7 @@ export const getGetSurveyUnitByIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -119,7 +119,7 @@ export function useGetSurveyUnitById<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetSurveyUnitById<
   TData = Awaited<ReturnType<typeof getSurveyUnitById>>,
@@ -143,7 +143,7 @@ export function useGetSurveyUnitById<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetSurveyUnitById<
   TData = Awaited<ReturnType<typeof getSurveyUnitById>>,
@@ -159,7 +159,7 @@ export function useGetSurveyUnitById<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get survey-unit
@@ -179,7 +179,7 @@ export function useGetSurveyUnitById<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetSurveyUnitByIdQueryOptions(id, options)
 
@@ -199,7 +199,7 @@ export function useGetSurveyUnitById<
 export const updateSurveyUnitById = (
   id: string,
   surveyUnitUpdate: SurveyUnitUpdate,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -208,7 +208,7 @@ export const updateSurveyUnitById = (
       headers: { 'Content-Type': 'application/json' },
       data: surveyUnitUpdate,
     },
-    options
+    options,
   )
 }
 
@@ -279,11 +279,11 @@ export const useUpdateSurveyUnitById = <
  */
 export const deleteSurveyUnit = (
   id: string,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     { url: `/api/survey-unit/${id}`, method: 'DELETE' },
-    options
+    options,
   )
 }
 
@@ -355,7 +355,7 @@ export const useDeleteSurveyUnit = <
 export const updateSurveyUnitDataStateDataById = (
   id: string,
   surveyUnitDataStateDataUpdate: SurveyUnitDataStateDataUpdate,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -364,7 +364,7 @@ export const updateSurveyUnitDataStateDataById = (
       headers: { 'Content-Type': 'application/json' },
       data: surveyUnitDataStateDataUpdate,
     },
-    options
+    options,
   )
 }
 
@@ -438,11 +438,11 @@ export const useUpdateSurveyUnitDataStateDataById = <
 export const getStateDataBySurveyUnit = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<StateData>(
     { url: `/api/survey-unit/${id}/state-data`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -464,7 +464,7 @@ export const getGetStateDataBySurveyUnitQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -514,7 +514,7 @@ export function useGetStateDataBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetStateDataBySurveyUnit<
   TData = Awaited<ReturnType<typeof getStateDataBySurveyUnit>>,
@@ -538,7 +538,7 @@ export function useGetStateDataBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetStateDataBySurveyUnit<
   TData = Awaited<ReturnType<typeof getStateDataBySurveyUnit>>,
@@ -554,7 +554,7 @@ export function useGetStateDataBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get state-data for a survey unit
@@ -574,7 +574,7 @@ export function useGetStateDataBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetStateDataBySurveyUnitQueryOptions(id, options)
 
@@ -594,7 +594,7 @@ export function useGetStateDataBySurveyUnit<
 export const setStateData = (
   id: string,
   stateDataUpdate: StateDataUpdate,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -603,7 +603,7 @@ export const setStateData = (
       headers: { 'Content-Type': 'application/json' },
       data: stateDataUpdate,
     },
-    options
+    options,
   )
 }
 
@@ -675,11 +675,11 @@ export const useSetStateData = <
 export const getPersonalizationBySurveyUnit = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SchemaPersonalization>(
     { url: `/api/survey-unit/${id}/personalization`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -701,7 +701,7 @@ export const getGetPersonalizationBySurveyUnitQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -751,7 +751,7 @@ export function useGetPersonalizationBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetPersonalizationBySurveyUnit<
   TData = Awaited<ReturnType<typeof getPersonalizationBySurveyUnit>>,
@@ -775,7 +775,7 @@ export function useGetPersonalizationBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetPersonalizationBySurveyUnit<
   TData = Awaited<ReturnType<typeof getPersonalizationBySurveyUnit>>,
@@ -791,7 +791,7 @@ export function useGetPersonalizationBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get personalization for a survey unit
@@ -811,11 +811,11 @@ export function useGetPersonalizationBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetPersonalizationBySurveyUnitQueryOptions(
     id,
-    options
+    options,
   )
 
   const query = useQuery(queryOptions) as UseQueryResult<TData, TError> & {
@@ -834,7 +834,7 @@ export function useGetPersonalizationBySurveyUnit<
 export const setPersonalization = (
   id: string,
   schemaPersonalization: SchemaPersonalization,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -843,7 +843,7 @@ export const setPersonalization = (
       headers: { 'Content-Type': 'application/json' },
       data: schemaPersonalization,
     },
-    options
+    options,
   )
 }
 
@@ -915,11 +915,11 @@ export const useSetPersonalization = <
 export const getDataBySurveyUnit = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SchemaData>(
     { url: `/api/survey-unit/${id}/data`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -941,7 +941,7 @@ export const getGetDataBySurveyUnitQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -990,7 +990,7 @@ export function useGetDataBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetDataBySurveyUnit<
   TData = Awaited<ReturnType<typeof getDataBySurveyUnit>>,
@@ -1014,7 +1014,7 @@ export function useGetDataBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetDataBySurveyUnit<
   TData = Awaited<ReturnType<typeof getDataBySurveyUnit>>,
@@ -1030,7 +1030,7 @@ export function useGetDataBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get data for a survey unit
@@ -1050,7 +1050,7 @@ export function useGetDataBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetDataBySurveyUnitQueryOptions(id, options)
 
@@ -1070,7 +1070,7 @@ export function useGetDataBySurveyUnit<
 export const updateData = (
   id: string,
   schemaData: SchemaData,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -1079,7 +1079,7 @@ export const updateData = (
       headers: { 'Content-Type': 'application/json' },
       data: schemaData,
     },
-    options
+    options,
   )
 }
 
@@ -1148,11 +1148,11 @@ export const useUpdateData = <TError = unknown, TContext = unknown>(options?: {
 export const getCommentBySurveyUnit = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<GetCommentBySurveyUnit200>(
     { url: `/api/survey-unit/${id}/comment`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -1174,7 +1174,7 @@ export const getGetCommentBySurveyUnitQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -1224,7 +1224,7 @@ export function useGetCommentBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetCommentBySurveyUnit<
   TData = Awaited<ReturnType<typeof getCommentBySurveyUnit>>,
@@ -1248,7 +1248,7 @@ export function useGetCommentBySurveyUnit<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetCommentBySurveyUnit<
   TData = Awaited<ReturnType<typeof getCommentBySurveyUnit>>,
@@ -1264,7 +1264,7 @@ export function useGetCommentBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get comment for a survey unit
@@ -1284,7 +1284,7 @@ export function useGetCommentBySurveyUnit<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetCommentBySurveyUnitQueryOptions(id, options)
 
@@ -1304,7 +1304,7 @@ export function useGetCommentBySurveyUnit<
 export const setComment = (
   id: string,
   setCommentBody: SetCommentBody,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -1313,7 +1313,7 @@ export const setComment = (
       headers: { 'Content-Type': 'application/json' },
       data: setCommentBody,
     },
-    options
+    options,
   )
 }
 
@@ -1381,7 +1381,7 @@ export const useSetComment = <TError = unknown, TContext = unknown>(options?: {
  */
 export const getStateDataBySurveyUnits = (
   getStateDataBySurveyUnitsBody: string[],
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<SurveyUnitsOkNok>(
     {
@@ -1390,7 +1390,7 @@ export const getStateDataBySurveyUnits = (
       headers: { 'Content-Type': 'application/json' },
       data: getStateDataBySurveyUnitsBody,
     },
-    options
+    options,
   )
 }
 
@@ -1462,7 +1462,7 @@ export const useGetStateDataBySurveyUnits = <
 export const createUpdateSurveyUnit = (
   id: string,
   surveyUnitCreation: SurveyUnitCreation,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -1471,7 +1471,7 @@ export const createUpdateSurveyUnit = (
       headers: { 'Content-Type': 'application/json' },
       data: surveyUnitCreation,
     },
-    options
+    options,
   )
 }
 
@@ -1542,11 +1542,11 @@ export const useCreateUpdateSurveyUnit = <
  */
 export const getSurveyUnitIds = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<string[]>(
     { url: `/api/survey-units`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -1656,11 +1656,11 @@ export function useGetSurveyUnitIds<
  */
 export const getInterviewerSurveyUnits = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SurveyUnit[]>(
     { url: `/api/survey-units/interviewer`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -1792,11 +1792,11 @@ export function useGetInterviewerSurveyUnits<
 export const getSurveyUnitMetadataById = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SurveyUnitMetadata>(
     { url: `/api/survey-unit/${id}/metadata`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -1818,7 +1818,7 @@ export const getGetSurveyUnitMetadataByIdQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -1868,7 +1868,7 @@ export function useGetSurveyUnitMetadataById<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetSurveyUnitMetadataById<
   TData = Awaited<ReturnType<typeof getSurveyUnitMetadataById>>,
@@ -1892,7 +1892,7 @@ export function useGetSurveyUnitMetadataById<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetSurveyUnitMetadataById<
   TData = Awaited<ReturnType<typeof getSurveyUnitMetadataById>>,
@@ -1908,7 +1908,7 @@ export function useGetSurveyUnitMetadataById<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get survey-unit metadata
@@ -1928,7 +1928,7 @@ export function useGetSurveyUnitMetadataById<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetSurveyUnitMetadataByIdQueryOptions(id, options)
 
@@ -1948,7 +1948,7 @@ export function useGetSurveyUnitMetadataById<
 export const generateDepositProof = (
   id: string,
   options?: SecondParameter<typeof depositProofInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return depositProofInstance<Blob>(
     {
@@ -1957,7 +1957,7 @@ export const generateDepositProof = (
       responseType: 'blob',
       signal,
     },
-    options
+    options,
   )
 }
 
@@ -1979,7 +1979,7 @@ export const getGenerateDepositProofQueryOptions = <
       >
     >
     request?: SecondParameter<typeof depositProofInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -2028,7 +2028,7 @@ export function useGenerateDepositProof<
         'initialData'
       >
     request?: SecondParameter<typeof depositProofInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGenerateDepositProof<
   TData = Awaited<ReturnType<typeof generateDepositProof>>,
@@ -2052,7 +2052,7 @@ export function useGenerateDepositProof<
         'initialData'
       >
     request?: SecondParameter<typeof depositProofInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGenerateDepositProof<
   TData = Awaited<ReturnType<typeof generateDepositProof>>,
@@ -2068,7 +2068,7 @@ export function useGenerateDepositProof<
       >
     >
     request?: SecondParameter<typeof depositProofInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get deposit proof for a survey unit
@@ -2088,7 +2088,7 @@ export function useGenerateDepositProof<
       >
     >
     request?: SecondParameter<typeof depositProofInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGenerateDepositProofQueryOptions(id, options)
 
@@ -2108,11 +2108,11 @@ export function useGenerateDepositProof<
 export const getListSurveyUnitByCampaign = (
   id: string,
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SurveyUnitSummary[]>(
     { url: `/api/campaign/${id}/survey-units`, method: 'GET', signal },
-    options
+    options,
   )
 }
 
@@ -2134,7 +2134,7 @@ export const getGetListSurveyUnitByCampaignQueryOptions = <
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ) => {
   const { query: queryOptions, request: requestOptions } = options ?? {}
 
@@ -2184,7 +2184,7 @@ export function useGetListSurveyUnitByCampaign<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): DefinedUseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetListSurveyUnitByCampaign<
   TData = Awaited<ReturnType<typeof getListSurveyUnitByCampaign>>,
@@ -2208,7 +2208,7 @@ export function useGetListSurveyUnitByCampaign<
         'initialData'
       >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 export function useGetListSurveyUnitByCampaign<
   TData = Awaited<ReturnType<typeof getListSurveyUnitByCampaign>>,
@@ -2224,7 +2224,7 @@ export function useGetListSurveyUnitByCampaign<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey }
 /**
  * @summary Get list of survey units for a campaign
@@ -2244,7 +2244,7 @@ export function useGetListSurveyUnitByCampaign<
       >
     >
     request?: SecondParameter<typeof stromaeInstance>
-  }
+  },
 ): UseQueryResult<TData, TError> & { queryKey: QueryKey } {
   const queryOptions = getGetListSurveyUnitByCampaignQueryOptions(id, options)
 

--- a/src/api/07-paradata-events.ts
+++ b/src/api/07-paradata-events.ts
@@ -22,7 +22,7 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  */
 export const addParadata = (
   addParadataBody: AddParadataBody,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -31,7 +31,7 @@ export const addParadata = (
       headers: { 'Content-Type': 'application/json' },
       data: addParadataBody,
     },
-    options
+    options,
   )
 }
 

--- a/src/api/08-survey-units-in-temp-zone.ts
+++ b/src/api/08-survey-units-in-temp-zone.ts
@@ -31,7 +31,7 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
 export const postSurveyUnitByIdInTempZone = (
   id: string,
   schemaSurveyUnitTempZone: SchemaSurveyUnitTempZone,
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     {
@@ -40,7 +40,7 @@ export const postSurveyUnitByIdInTempZone = (
       headers: { 'Content-Type': 'application/json' },
       data: schemaSurveyUnitTempZone,
     },
-    options
+    options,
   )
 }
 
@@ -112,11 +112,11 @@ export const usePostSurveyUnitByIdInTempZone = <
  */
 export const getSurveyUnitsInTempZone = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<SurveyUnitTempZone[]>(
     { url: `/api/survey-units/temp-zone`, method: 'GET', signal },
-    options
+    options,
   )
 }
 

--- a/src/api/09-healthcheck.ts
+++ b/src/api/09-healthcheck.ts
@@ -24,11 +24,11 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  */
 export const healthCheck = (
   options?: SecondParameter<typeof stromaeInstance>,
-  signal?: AbortSignal
+  signal?: AbortSignal,
 ) => {
   return stromaeInstance<void>(
     { url: `/api/healthcheck`, method: 'GET', signal },
-    options
+    options,
   )
 }
 

--- a/src/api/10-create-data-set.ts
+++ b/src/api/10-create-data-set.ts
@@ -20,11 +20,11 @@ type SecondParameter<T extends (...args: any) => any> = Parameters<T>[1]
  * @summary Create dataset
  */
 export const createDataSet = (
-  options?: SecondParameter<typeof stromaeInstance>
+  options?: SecondParameter<typeof stromaeInstance>,
 ) => {
   return stromaeInstance<void>(
     { url: `/api/create-dataset`, method: 'POST' },
-    options
+    options,
   )
 }
 

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -39,7 +39,7 @@ axiosInstance.interceptors.request.use(onRequest)
 // add a second `options` argument here if you want to pass extra options to each generated query
 export const stromaeInstance = <T>(
   config: AxiosRequestConfig,
-  options?: AxiosRequestConfig
+  options?: AxiosRequestConfig,
 ) => {
   return axiosInstance<T>({
     ...config,
@@ -50,7 +50,7 @@ export const stromaeInstance = <T>(
 //We use a customInstance for depositProof because we need response headers to get fileName.
 export const depositProofInstance = <T>(
   config: AxiosRequestConfig,
-  options?: AxiosRequestConfig
+  options?: AxiosRequestConfig,
 ) => {
   return axiosInstance<T>({
     ...config,

--- a/src/contexts/TelemetryContext.tsx
+++ b/src/contexts/TelemetryContext.tsx
@@ -72,7 +72,7 @@ export function TelemetryProvider({
     (event: TelemetryParadata) => {
       addDatum({ ...defaultValues, ...event })
     },
-    [addDatum, defaultValues]
+    [addDatum, defaultValues],
   )
 
   /** Add values that will be appended to every telemetry event (e.g. user id) */
@@ -83,7 +83,7 @@ export function TelemetryProvider({
         ...newDefaultValues,
       }))
     },
-    []
+    [],
   )
 
   const telemetryContextValues = useMemo(
@@ -93,7 +93,7 @@ export function TelemetryProvider({
       setDefaultValues: updateDefaultValues,
       triggerBatchTelemetryCallback: triggerTimeoutEvent,
     }),
-    [isTelemetryDisabled, pushEvent, triggerTimeoutEvent, updateDefaultValues]
+    [isTelemetryDisabled, pushEvent, triggerTimeoutEvent, updateDefaultValues],
   )
 
   return (

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -20,5 +20,5 @@ export const {
     en: () => import('./resources/en').then(({ translations }) => translations),
     fr: () => import('./resources/fr').then(({ translations }) => translations),
     sq: () => import('./resources/sq').then(({ translations }) => translations),
-  }
+  },
 )

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,5 +5,5 @@ import { App } from './App'
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 )

--- a/src/pages/Collect/CollectPage.tsx
+++ b/src/pages/Collect/CollectPage.tsx
@@ -31,7 +31,7 @@ export const CollectPage = memo(function CollectPage() {
       queryClient
         .ensureQueryData(getGetNomenclatureByIdQueryOptions(name))
         .then((result) => result as Nomenclature),
-    [queryClient]
+    [queryClient],
   )
 
   const queryKeyToInvalidate = getGetSurveyUnitByIdQueryKey(surveyUnitId)
@@ -76,7 +76,7 @@ export const CollectPage = memo(function CollectPage() {
       .then((response) => {
         const fileName =
           (response.headers['content-disposition']?.match(
-            /filename="(.+?)"/
+            /filename="(.+?)"/,
           )[1] as string) ?? 'document.pdf' //content-disposition is present in OpenAPI spec but not well inferred by type
 
         const url = URL.createObjectURL(response.data)

--- a/src/pages/Collect/route.tsx
+++ b/src/pages/Collect/route.tsx
@@ -38,7 +38,7 @@ export const collectRoute = createRoute({
       .ensureQueryData(
         getGetQuestionnaireDataQueryOptions(questionnaireId, {
           request: { signal: abortController.signal },
-        })
+        }),
       )
       .then((e) => e as unknown as LunaticSource) // We'd like to use zod, but the files are heavy.
 
@@ -46,14 +46,14 @@ export const collectRoute = createRoute({
     const surveyUnitDataPr = getSurveyUnitById(
       surveyUnitId,
       undefined,
-      abortController.signal
+      abortController.signal,
     ).then((suData) => suData as SurveyUnitData) // data are heavy too
 
     const metadataPr = queryClient
       .ensureQueryData(
         getGetSurveyUnitMetadataByIdQueryOptions(surveyUnitId, {
           request: { signal: abortController.signal },
-        })
+        }),
       )
       .then((metadata) => {
         document.title = metadata.label ?? "Questionnaire | Filière d'Enquête"
@@ -71,7 +71,7 @@ export const collectRoute = createRoute({
         source,
         surveyUnitData,
         metadata,
-      })
+      }),
     )
   },
   // Do not cache this route's data after it's unloaded

--- a/src/pages/NavigationAssistance/NavigationAssistancePage.tsx
+++ b/src/pages/NavigationAssistance/NavigationAssistancePage.tsx
@@ -19,7 +19,7 @@ export const NavigationAssistancePage = memo(
         {t('navigation assistance content')}
       </Grid>
     )
-  }
+  },
 )
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/pages/Review/route.tsx
+++ b/src/pages/Review/route.tsx
@@ -34,7 +34,7 @@ export const reviewRoute = createRoute({
       .ensureQueryData(
         getGetQuestionnaireDataQueryOptions(questionnaireId, {
           request: { signal: abortController.signal },
-        })
+        }),
       )
       .then((e) => e as unknown as LunaticSource) // We'd like to use zod, but the files are heavy.
 
@@ -42,7 +42,7 @@ export const reviewRoute = createRoute({
       .ensureQueryData(
         getGetSurveyUnitByIdQueryOptions(surveyUnitId, {
           request: { signal: abortController.signal },
-        })
+        }),
       )
       .then((suData) => suData as SurveyUnitData) // data are heavy too
 
@@ -50,7 +50,7 @@ export const reviewRoute = createRoute({
       .ensureQueryData(
         getGetSurveyUnitMetadataByIdQueryOptions(surveyUnitId, {
           request: { signal: abortController.signal },
-        })
+        }),
       )
       .then((metadata) => {
         document.title =
@@ -69,7 +69,7 @@ export const reviewRoute = createRoute({
         source,
         surveyUnitData,
         metadata,
-      })
+      }),
     )
   },
   errorComponent: ({ error }) => {

--- a/src/pages/Visualize/Form/VisualizeForm.tsx
+++ b/src/pages/Visualize/Form/VisualizeForm.tsx
@@ -39,7 +39,7 @@ export function VisualizeForm() {
         metadata,
         nomenclature: nomenclature.reduce(
           (acc, { name, uri }) => ({ ...acc, [name]: uri }),
-          {}
+          {},
         ),
       },
     })

--- a/src/pages/Visualize/Visualize.tsx
+++ b/src/pages/Visualize/Visualize.tsx
@@ -23,11 +23,11 @@ export const VisualizePage = memo(function VisualizePage() {
 
     if (!nomenclature[name]) {
       return Promise.reject(
-        new Error(`The nomenclature ${name} is not provided`)
+        new Error(`The nomenclature ${name} is not provided`),
       )
     }
     return queryClient.ensureQueryData(
-      nomenclatureQueryOptions(nomenclature[name])
+      nomenclatureQueryOptions(nomenclature[name]),
     )
   }
 

--- a/src/pages/Visualize/route.tsx
+++ b/src/pages/Visualize/route.tsx
@@ -46,14 +46,14 @@ export const visualizeRoute = createRoute({
     }
 
     const sourcePr = queryClient.ensureQueryData(
-      sourceQueryOptions(sourceUrl, { signal: abortController.signal })
+      sourceQueryOptions(sourceUrl, { signal: abortController.signal }),
     )
 
     const surveyUnitDataPr = surveyUnitDataUrl
       ? queryClient.ensureQueryData(
           surveyUnitDataQueryOptions(surveyUnitDataUrl, {
             signal: abortController.signal,
-          })
+          }),
         )
       : Promise.resolve(undefined)
 
@@ -62,7 +62,7 @@ export const visualizeRoute = createRoute({
           .ensureQueryData(
             metadataQueryOptions(metadataUrl, {
               signal: abortController.signal,
-            })
+            }),
           )
           .then((metadata) => {
             if (metadata.label) {
@@ -73,7 +73,7 @@ export const visualizeRoute = createRoute({
               mainLogo: metadata.logos?.main,
               secondariesLogo: metadata.logos?.secondaries,
               surveyUnitInfo: convertOldPersonalization(
-                metadata.personalization
+                metadata.personalization,
               ),
             })
           })
@@ -82,7 +82,7 @@ export const visualizeRoute = createRoute({
     return Promise.all([sourcePr, surveyUnitDataPr, metadataPr]).then(
       ([source, surveyUnitData, metadata]) => {
         return { source, surveyUnitData, metadata, nomenclature }
-      }
+      },
     )
   },
   errorComponent: ({ error, reset }) => (

--- a/src/shared/components/Error/ErrorComponent.tsx
+++ b/src/shared/components/Error/ErrorComponent.tsx
@@ -31,7 +31,7 @@ export function ErrorComponent(props: Props) {
         className={fr.cx(
           'fr-grid-row',
           'fr-grid-row--center',
-          'fr-grid-row--middle'
+          'fr-grid-row--middle',
         )}
       >
         <div className={fr.cx('fr-col-lg-6', 'fr-col-12')}>
@@ -70,7 +70,7 @@ export function ErrorComponent(props: Props) {
             'fr-col-lg-3',
             'fr-col-offset-lg-1',
             'fr-hidden',
-            'fr-unhidden-lg'
+            'fr-unhidden-lg',
           )}
         >
           <svg

--- a/src/shared/components/Layout/AutoLogoutCountdown.tsx
+++ b/src/shared/components/Layout/AutoLogoutCountdown.tsx
@@ -19,8 +19,8 @@ export function AutoLogoutCountdown() {
           setSecondsLeft(
             secondsLeft === undefined || secondsLeft > 60
               ? undefined
-              : secondsLeft
-          )
+              : secondsLeft,
+          ),
         )
 
       return () => {
@@ -32,7 +32,7 @@ export function AutoLogoutCountdown() {
     // Unless you're hot swapping the oidc context isUserLoggedIn
     // and subscribeToAutoLogoutCountdown never change for the
     // lifetime of the app.
-    [isUserLoggedIn, subscribeToAutoLogoutCountdown]
+    [isUserLoggedIn, subscribeToAutoLogoutCountdown],
   )
 
   if (secondsLeft === undefined) {

--- a/src/shared/components/Layout/Footer.tsx
+++ b/src/shared/components/Layout/Footer.tsx
@@ -15,7 +15,7 @@ const transformLogo = (
   logo: Logo,
   resolveLocalizedString: ReturnType<
     typeof useResolveLocalizedString
-  >['resolveLocalizedStringDetailed']
+  >['resolveLocalizedStringDetailed'],
 ) => ({
   alt: resolveLocalizedString(logo.label).str,
   imgUrl: logo.url,

--- a/src/shared/components/Layout/Header.test.tsx
+++ b/src/shared/components/Layout/Header.test.tsx
@@ -29,7 +29,7 @@ describe('Header', () => {
         >
           <Header />
         </TelemetryContext.Provider>
-      </OidcProvider>
+      </OidcProvider>,
     )
 
     await waitFor(() => expect(pushEvent).not.toHaveBeenCalled())
@@ -42,8 +42,8 @@ describe('Header', () => {
       expect(pushEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: TELEMETRY_EVENT_TYPE.CONTACT_SUPPORT,
-        })
-      )
+        }),
+      ),
     )
   })
 
@@ -64,7 +64,7 @@ describe('Header', () => {
         >
           <Header />
         </TelemetryContext.Provider>
-      </OidcProvider>
+      </OidcProvider>,
     )
 
     await waitFor(() => expect(pushEvent).not.toHaveBeenCalled())
@@ -92,7 +92,7 @@ describe('Header', () => {
         >
           <Header />
         </TelemetryContext.Provider>
-      </OidcProvider>
+      </OidcProvider>,
     )
 
     await waitFor(() => expect(pushEvent).not.toHaveBeenCalled())

--- a/src/shared/components/Layout/Header.tsx
+++ b/src/shared/components/Layout/Header.tsx
@@ -82,7 +82,7 @@ export function Header() {
                       pushEvent(
                         computeExitEvent({
                           source: TELEMETRY_EVENT_EXIT_SOURCE.LOGOUT,
-                        })
+                        }),
                       )
                       if (triggerBatchTelemetryCallback) {
                         await triggerBatchTelemetryCallback()

--- a/src/shared/components/Orchestrator/CustomPages/EndPage.test.tsx
+++ b/src/shared/components/Orchestrator/CustomPages/EndPage.test.tsx
@@ -10,8 +10,8 @@ describe('EndPage', () => {
 
     expect(
       getByText(
-        `Your responses were sent on ${new Date(date).toLocaleString()}.`
-      )
+        `Your responses were sent on ${new Date(date).toLocaleString()}.`,
+      ),
     ).toBeInTheDocument()
   })
 
@@ -25,7 +25,7 @@ describe('EndPage', () => {
     const date = 1728289634098
 
     const { getByText, queryByText } = render(
-      <EndPage date={date} state={'TOEXTRACT'} />
+      <EndPage date={date} state={'TOEXTRACT'} />,
     )
 
     expect(getByText('Your responses were sent.')).toBeInTheDocument()
@@ -36,7 +36,7 @@ describe('EndPage', () => {
     const date = 1728289634098
 
     const { getByText, queryByText } = render(
-      <EndPage date={date} state={'EXTRACTED'} />
+      <EndPage date={date} state={'EXTRACTED'} />,
     )
 
     expect(getByText('Your responses were sent.')).toBeInTheDocument()

--- a/src/shared/components/Orchestrator/CustomPages/ValidationModal.tsx
+++ b/src/shared/components/Orchestrator/CustomPages/ValidationModal.tsx
@@ -16,7 +16,7 @@ export function ValidationModal({ actionsRef }: Props) {
     createModal({
       id: `validationModal-${id}`,
       isOpenedByDefault: false,
-    })
+    }),
   )
 
   const [openState, setOpenState] = useState<

--- a/src/shared/components/Orchestrator/CustomPages/WelcomePage.test.tsx
+++ b/src/shared/components/Orchestrator/CustomPages/WelcomePage.test.tsx
@@ -39,7 +39,7 @@ describe('WelcomePage', () => {
           mainLogo: { label: '', url: '' },
           surveyUnitIdentifier: 'Id de la personne qui répond',
         }}
-      />
+      />,
     )
 
     expect(getByText(objectives)).toBeInTheDocument()

--- a/src/shared/components/Orchestrator/Orchestrator.test.tsx
+++ b/src/shared/components/Orchestrator/Orchestrator.test.tsx
@@ -78,14 +78,14 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.COLLECT} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     await waitFor(() => expect(setDefaultValues).toHaveBeenCalledOnce())
     await waitFor(() =>
       expect(setDefaultValues).toHaveBeenCalledWith({
         idSU: 'my-service-unit-id',
-      })
+      }),
     )
   })
 
@@ -101,7 +101,7 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.COLLECT} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     await waitFor(() => expect(pushEvent).toHaveBeenCalledOnce())
@@ -109,8 +109,8 @@ describe('Orchestrator', () => {
       expect(pushEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: TELEMETRY_EVENT_TYPE.INIT,
-        })
-      )
+        }),
+      ),
     )
   })
 
@@ -126,7 +126,7 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.VISUALIZE} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     await waitFor(() => expect(pushEvent).not.toHaveBeenCalled())
@@ -146,7 +146,7 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.REVIEW} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     await waitFor(() => expect(pushEvent).not.toHaveBeenCalled())
@@ -166,7 +166,7 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.COLLECT} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     await waitFor(() => expect(pushEvent).not.toHaveBeenCalled())
@@ -186,7 +186,7 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.COLLECT} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     act(() => getByText('Start').click())
@@ -195,7 +195,7 @@ describe('Orchestrator', () => {
     expect(pushEvent).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: TELEMETRY_EVENT_TYPE.NEW_PAGE,
-      })
+      }),
     )
   })
 
@@ -212,7 +212,7 @@ describe('Orchestrator', () => {
         }}
       >
         <OrchestratorTestWrapper mode={MODE_TYPE.COLLECT} />
-      </TelemetryContext.Provider>
+      </TelemetryContext.Provider>,
     )
 
     act(() => getByText('Start').click())
@@ -226,7 +226,7 @@ describe('Orchestrator', () => {
     expect(pushEvent).toHaveBeenLastCalledWith(
       expect.objectContaining({
         type: TELEMETRY_EVENT_TYPE.INPUT,
-      })
+      }),
     )
   })
 })

--- a/src/shared/components/Orchestrator/Orchestrator.tsx
+++ b/src/shared/components/Orchestrator/Orchestrator.tsx
@@ -127,7 +127,7 @@ export function Orchestrator(props: OrchestratorProps) {
   /** Displays the welcome modal which allows to come back to current page */
   const shouldWelcome = shouldDisplayWelcomeModal(
     initialState,
-    initialCurrentPage
+    initialCurrentPage,
   )
 
   const lunaticLogger = useMemo(
@@ -135,7 +135,7 @@ export function Orchestrator(props: OrchestratorProps) {
       mode === MODE_TYPE.VISUALIZE
         ? createLunaticLogger({ pageTag: pageTagRef })
         : undefined,
-    [mode]
+    [mode],
   )
 
   /** Triggers telemetry input event on Lunatic change */
@@ -149,7 +149,7 @@ export function Orchestrator(props: OrchestratorProps) {
           computeInputEvent({
             name: name,
             iteration: iteration,
-          })
+          }),
         )
       } else {
         for (const { name, iteration } of changes) {
@@ -158,12 +158,12 @@ export function Orchestrator(props: OrchestratorProps) {
             computeInputEvent({
               name: name,
               iteration: iteration,
-            })
+            }),
           )
         }
       }
     },
-    [pushEvent, setEventToPushAfterInactivity]
+    [pushEvent, setEventToPushAfterInactivity],
   )
 
   const {
@@ -198,7 +198,7 @@ export function Orchestrator(props: OrchestratorProps) {
 
   // current date to show in end page on validation
   const [lastUpdateDate, setLastUpdateDate] = useState<number | undefined>(
-    surveyUnitData?.stateData?.date
+    surveyUnitData?.stateData?.date,
   )
   // whether or not the user has seen the errors and did not change anything
   const [isControlsAcknowledged, setIsControlsAcknowledged] =
@@ -227,7 +227,7 @@ export function Orchestrator(props: OrchestratorProps) {
         pushEvent(
           computeControlSkipEvent({
             controlIds: Object.keys(currentErrors),
-          })
+          }),
         )
       }
       setActiveErrors(undefined)
@@ -243,7 +243,7 @@ export function Orchestrator(props: OrchestratorProps) {
       pushEvent(
         computeControlEvent({
           controlIds: Object.keys(currentErrors),
-        })
+        }),
       )
     }
 
@@ -357,7 +357,7 @@ export function Orchestrator(props: OrchestratorProps) {
         computeNewPageEvent({
           page: currentPage,
           pageTag,
-        })
+        }),
       )
       if (currentPage === PAGE_TYPE.END) {
         if (triggerBatchTelemetryCallback) {
@@ -404,7 +404,7 @@ export function Orchestrator(props: OrchestratorProps) {
 
   const { components, bottomComponents } = computeLunaticComponents(
     getComponents(),
-    pagination
+    pagination,
   )
 
   const handleDepositProofClick = async () => {

--- a/src/shared/components/Orchestrator/SequenceHeader.tsx
+++ b/src/shared/components/Orchestrator/SequenceHeader.tsx
@@ -13,7 +13,7 @@ export function SequenceHeader(props: SequenceHeaderProps) {
 
   const { t } = useTranslation('SequenceHeader')
   const currentSequenceIndex = overview.findIndex(
-    (sequence) => sequence.current
+    (sequence) => sequence.current,
   )
 
   if (currentSequenceIndex === -1) {

--- a/src/shared/components/Orchestrator/SurveyContainer.tsx
+++ b/src/shared/components/Orchestrator/SurveyContainer.tsx
@@ -21,7 +21,7 @@ export function SurveyContainer(
     overview: LunaticOverview
     isSequencePage: boolean
     bottomContent: ReactNode
-  }>
+  }>,
 ) {
   const {
     currentPage,
@@ -40,7 +40,7 @@ export function SurveyContainer(
   const { t } = useTranslation({ SurveyContainer })
 
   const isPreviousButtonDisplayed = [PAGE_TYPE.WELCOME, PAGE_TYPE.END].includes(
-    currentPage
+    currentPage,
   )
 
   const [isLayoutExpanded, setIsLayoutExpanded] = useState<boolean>(false)
@@ -79,7 +79,7 @@ export function SurveyContainer(
                   'fr-hidden',
                   'fr-unhidden-md',
                   'fr-col-offset-8',
-                  'fr-col-offset-md-9'
+                  'fr-col-offset-md-9',
                 )}
               >
                 <Button
@@ -106,7 +106,7 @@ export function SurveyContainer(
               'fr-mb-10v',
               ...(!(isLayoutExpanded && currentPage === PAGE_TYPE.LUNATIC)
                 ? (['fr-col-md-9', 'fr-col-lg-8'] as const)
-                : [])
+                : []),
             )}
           >
             {children}

--- a/src/shared/components/Orchestrator/VTLDevTools/VTLDevtools.tsx
+++ b/src/shared/components/Orchestrator/VTLDevTools/VTLDevtools.tsx
@@ -65,7 +65,7 @@ export const VTLDevTools = () => {
             className={fr.cx(
               'fr-table',
               'fr-table--lg',
-              'fr-table--no-caption'
+              'fr-table--no-caption',
             )}
           >
             <div className={fr.cx('fr-table__header')}>
@@ -132,7 +132,7 @@ const { i18n } = declareComponentKeys<
 export type I18n = typeof i18n
 
 const hasBindings = (
-  error: VTLExpressionError
+  error: VTLExpressionError,
 ): error is VTLInterpretationError => {
   return error instanceof VTLInterpretationError
 }

--- a/src/shared/components/Orchestrator/VTLDevTools/VTLErrorStore.tsx
+++ b/src/shared/components/Orchestrator/VTLDevTools/VTLErrorStore.tsx
@@ -59,7 +59,7 @@ const errorStore = createErrorStore()
 export const useLoggerErrors = () => {
   const errors = useSyncExternalStore(
     errorStore.subscribe,
-    errorStore.getErrors
+    errorStore.getErrors,
   )
 
   const resetErrors = () => {

--- a/src/shared/components/Orchestrator/usePushEventAfterInactivity.test.ts
+++ b/src/shared/components/Orchestrator/usePushEventAfterInactivity.test.ts
@@ -12,8 +12,8 @@ describe('Use push event after inactivity', () => {
 
     act(() =>
       result.current.setEventToPushAfterInactivity(
-        computeInputEvent({ name: 'my-input' })
-      )
+        computeInputEvent({ name: 'my-input' }),
+      ),
     )
 
     expect(mock).not.toHaveBeenCalled()
@@ -24,7 +24,7 @@ describe('Use push event after inactivity', () => {
     expect(mock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'my-input',
-      })
+      }),
     )
   })
 
@@ -37,16 +37,16 @@ describe('Use push event after inactivity', () => {
 
     act(() =>
       result.current.setEventToPushAfterInactivity(
-        computeInputEvent({ name: 'my-input' })
-      )
+        computeInputEvent({ name: 'my-input' }),
+      ),
     )
 
     expect(mock).not.toHaveBeenCalled()
 
     act(() =>
       result.current.setEventToPushAfterInactivity(
-        computeInputEvent({ name: 'my-input' })
-      )
+        computeInputEvent({ name: 'my-input' }),
+      ),
     )
 
     await new Promise((r) => setTimeout(r, 50))
@@ -55,7 +55,7 @@ describe('Use push event after inactivity', () => {
     expect(mock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'my-input',
-      })
+      }),
     )
   })
 
@@ -68,23 +68,23 @@ describe('Use push event after inactivity', () => {
 
     act(() =>
       result.current.setEventToPushAfterInactivity(
-        computeInputEvent({ name: 'my-input' })
-      )
+        computeInputEvent({ name: 'my-input' }),
+      ),
     )
 
     expect(mock).not.toHaveBeenCalled()
 
     act(() =>
       result.current.setEventToPushAfterInactivity(
-        computeInputEvent({ name: 'my-input-2' })
-      )
+        computeInputEvent({ name: 'my-input-2' }),
+      ),
     )
 
     expect(mock).toHaveBeenCalledOnce()
     expect(mock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'my-input',
-      })
+      }),
     )
 
     await new Promise((r) => setTimeout(r, 60))
@@ -93,7 +93,7 @@ describe('Use push event after inactivity', () => {
     expect(mock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         name: 'my-input-2',
-      })
+      }),
     )
   })
 
@@ -106,8 +106,8 @@ describe('Use push event after inactivity', () => {
 
     act(() =>
       result.current.setEventToPushAfterInactivity(
-        computeInputEvent({ name: 'my-input' })
-      )
+        computeInputEvent({ name: 'my-input' }),
+      ),
     )
 
     expect(mock).not.toHaveBeenCalled()
@@ -118,7 +118,7 @@ describe('Use push event after inactivity', () => {
     expect(mock).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'my-input',
-      })
+      }),
     )
   })
 })

--- a/src/shared/components/Orchestrator/usePushEventAfterInactivity.ts
+++ b/src/shared/components/Orchestrator/usePushEventAfterInactivity.ts
@@ -11,14 +11,14 @@ const defaultInactivityDelay = 1_000
  */
 export function usePushEventAfterInactivity(
   pushEventAfterInactivity: (e: InputParadata & CommonParadata) => void,
-  inactivityDelay: number = defaultInactivityDelay
+  inactivityDelay: number = defaultInactivityDelay,
 ) {
   const [event, setEvent] = useState<
     (InputParadata & CommonParadata) | undefined
   >(undefined)
   const timerRef = useRef<NodeJS.Timeout | undefined>(undefined)
   const previousEventRef = useRef<(InputParadata & CommonParadata) | undefined>(
-    undefined
+    undefined,
   )
 
   useEffect(() => {

--- a/src/shared/components/Orchestrator/useStromaeNavigation.tsx
+++ b/src/shared/components/Orchestrator/useStromaeNavigation.tsx
@@ -30,7 +30,7 @@ export function useStromaeNavigation({
   openValidationModal,
 }: Params) {
   const [currentPage, setCurrentPage] = useState<InternalPageType>(() =>
-    initialCurrentPage === PAGE_TYPE.END ? PAGE_TYPE.END : PAGE_TYPE.WELCOME
+    initialCurrentPage === PAGE_TYPE.END ? PAGE_TYPE.END : PAGE_TYPE.WELCOME,
   )
 
   const goNextFromLunaticPage = (isLastPage: boolean) => {
@@ -74,7 +74,7 @@ export function useStromaeNavigation({
       | {
           page: StromaePage
         }
-      | Parameters<LunaticGoToPage>[0]
+      | Parameters<LunaticGoToPage>[0],
   ) => {
     switch (params.page) {
       case PAGE_TYPE.VALIDATION:

--- a/src/shared/components/Orchestrator/utils/components.ts
+++ b/src/shared/components/Orchestrator/utils/components.ts
@@ -3,7 +3,7 @@ import type { LunaticComponentsProps } from './lunaticType'
 
 export function computeLunaticComponents(
   lunaticComponents: LunaticComponentProps[],
-  pagination: 'sequence' | 'question' | undefined
+  pagination: 'sequence' | 'question' | undefined,
 ): {
   components: LunaticComponentsProps
   bottomComponents: LunaticComponentsProps
@@ -31,6 +31,6 @@ export function computeLunaticComponents(
         bottomComponents: acc.bottomComponents,
       }
     },
-    { components: [], bottomComponents: [] }
+    { components: [], bottomComponents: [] },
   )
 }

--- a/src/shared/components/Orchestrator/utils/controls.ts
+++ b/src/shared/components/Orchestrator/utils/controls.ts
@@ -4,7 +4,7 @@ export function isBlockingError(errors: Record<string, LunaticError[]>) {
   return Object.values(errors).some((errorArray) =>
     errorArray.some(
       (error) =>
-        error.typeOfControl === 'FORMAT' || error.criticality === 'ERROR'
-    )
+        error.typeOfControl === 'FORMAT' || error.criticality === 'ERROR',
+    ),
   )
 }

--- a/src/shared/components/Orchestrator/utils/data.ts
+++ b/src/shared/components/Orchestrator/utils/data.ts
@@ -5,7 +5,7 @@ import type { LunaticData } from '@inseefr/lunatic'
  * (i.e. everything except COLLECTED)
  */
 export function trimCollectedData(
-  data: LunaticData['COLLECTED']
+  data: LunaticData['COLLECTED'],
 ): LunaticData['COLLECTED'] {
   const trimmedData = Object.assign({}, data)
   for (const key in trimmedData) {

--- a/src/shared/components/Orchestrator/utils/scrollAndFocusToFirstError.ts
+++ b/src/shared/components/Orchestrator/utils/scrollAndFocusToFirstError.ts
@@ -1,6 +1,6 @@
 export function scrollAndFocusToFirstError() {
   const errorElement = document.querySelector<HTMLElement>(
-    '[aria-invalid="true"],[role="alert"]'
+    '[aria-invalid="true"],[role="alert"]',
   )
 
   if (errorElement) {

--- a/src/shared/hooks/prelogout.ts
+++ b/src/shared/hooks/prelogout.ts
@@ -10,7 +10,7 @@ export async function executePreLogoutActions() {
 }
 
 export function useAddPreLogoutAction(
-  action: () => Promise<void> | void
+  action: () => Promise<void> | void,
 ): void {
   const stableAction = useEvent(action)
   useEffect(() => {

--- a/src/shared/hooks/useBatch.ts
+++ b/src/shared/hooks/useBatch.ts
@@ -7,7 +7,7 @@ const defaultInactivityDelay = 60_000
 export function useBatch(
   callback: (data: Array<any>) => Promise<void>,
   dataMaxLength: number = defaultDataMaxLength,
-  inactivityDelay: number = defaultInactivityDelay
+  inactivityDelay: number = defaultInactivityDelay,
 ) {
   const [data, setData] = useState<Array<any>>([])
   const dataRef = useRef<Array<any>>([])
@@ -43,7 +43,7 @@ export function useBatch(
     (e: any) => {
       setData((data) => [...data, e])
     },
-    [setData]
+    [setData],
   )
 
   const triggerTimeoutEvent: () => Promise<void> =

--- a/src/shared/loader/protectedLoader.ts
+++ b/src/shared/loader/protectedLoader.ts
@@ -1,7 +1,7 @@
 import { getOidc } from '@/oidc'
 
 export async function protectedRouteLoader(
-  extraQueryParams?: Record<string, string>
+  extraQueryParams?: Record<string, string>,
 ) {
   const oidc = await getOidc()
 

--- a/src/shared/metadataStore/metadataStore.ts
+++ b/src/shared/metadataStore/metadataStore.ts
@@ -45,7 +45,7 @@ export const metadataStore = {
         }
         return acc
       },
-      { ...state }
+      { ...state },
     )
 
     state = updatedState

--- a/src/shared/metadataStore/useMetadataStore.tsx
+++ b/src/shared/metadataStore/useMetadataStore.tsx
@@ -4,7 +4,7 @@ import { metadataStore } from './metadataStore'
 export const useMetadataStore = () => {
   const state = useSyncExternalStore(
     metadataStore.subscribe,
-    metadataStore.getSnapshot
+    metadataStore.getSnapshot,
   )
   return state
 }

--- a/src/shared/parser/metadata.ts
+++ b/src/shared/parser/metadata.ts
@@ -35,7 +35,7 @@ export const surveyUnitMetadataSchema = z.object({
       z.object({
         name: z.string(),
         value: z.string(),
-      })
+      }),
     )
     .optional(),
   surveyUnitIdentifier: z.string().optional(),

--- a/src/shared/query/visualizeQueryOptions.ts
+++ b/src/shared/query/visualizeQueryOptions.ts
@@ -14,7 +14,7 @@ function axiosGet<T>(url: string, options?: AxiosRequestConfig) {
 
 export const sourceQueryOptions = (
   sourceUrl: string,
-  options?: AxiosRequestConfig
+  options?: AxiosRequestConfig,
 ) =>
   queryOptions({
     queryKey: [sourceUrl],
@@ -23,7 +23,7 @@ export const sourceQueryOptions = (
 
 export const surveyUnitDataQueryOptions = (
   surveyUnitDataUrl: string,
-  options?: AxiosRequestConfig
+  options?: AxiosRequestConfig,
 ) =>
   queryOptions({
     queryKey: [surveyUnitDataUrl],
@@ -32,7 +32,7 @@ export const surveyUnitDataQueryOptions = (
 
 export const metadataQueryOptions = (
   metadataUrl: string,
-  options?: AxiosRequestConfig
+  options?: AxiosRequestConfig,
 ) =>
   queryOptions({
     queryKey: [metadataUrl],
@@ -49,7 +49,7 @@ export const metadataQueryOptions = (
 
 export const nomenclatureQueryOptions = (
   nomenclatureUrl: string,
-  options?: AxiosRequestConfig
+  options?: AxiosRequestConfig,
 ) =>
   queryOptions({
     queryKey: [nomenclatureUrl],

--- a/src/shared/toast/Toast.tsx
+++ b/src/shared/toast/Toast.tsx
@@ -26,6 +26,6 @@ export const showToast = (params: Params) => {
     {
       position: isMobileScreen() ? 'bottom-center' : 'top-right',
       duration: 1500,
-    }
+    },
   )
 }

--- a/src/utils/convertOldPersonalization.ts
+++ b/src/utils/convertOldPersonalization.ts
@@ -4,7 +4,7 @@ import type { Content, Metadata } from '@/model/Metadata'
 const keysToExtract = ['whoAnswers1', 'whoAnswers2', 'whoAnswers3']
 
 export function convertContent(
-  personalization: SurveyUnitMetadata['personalization']
+  personalization: SurveyUnitMetadata['personalization'],
 ): Content | undefined {
   const textItems = personalization
     ?.filter((item) => keysToExtract.includes(item.name) && item.value !== '')
@@ -23,7 +23,7 @@ export function convertContent(
  * Temporary function before the api move to new Schema described here @url https://github.com/InseeFr/stromae-dsfr/issues/81#issuecomment-2216825059
  */
 export function convertOldPersonalization(
-  personalization: SurveyUnitMetadata['personalization']
+  personalization: SurveyUnitMetadata['personalization'],
 ): Metadata['surveyUnitInfo'] {
   const contentBlock = convertContent(personalization)
 

--- a/src/utils/orchestrator.ts
+++ b/src/utils/orchestrator.ts
@@ -11,7 +11,7 @@ export function hasBeenSent(state?: StateData['state']): boolean {
 // and it's not been sent yet
 export function shouldDisplayWelcomeModal(
   state?: StateData['state'],
-  page?: PageType
+  page?: PageType,
 ): boolean {
   return !hasBeenSent(state) && page !== PAGE_TYPE.WELCOME && page !== undefined
 }

--- a/src/utils/telemetry.test.ts
+++ b/src/utils/telemetry.test.ts
@@ -32,7 +32,7 @@ describe('compute telemetry events', () => {
 
   test('for exit', () => {
     expect(
-      computeExitEvent({ source: TELEMETRY_EVENT_EXIT_SOURCE.LOGOUT })
+      computeExitEvent({ source: TELEMETRY_EVENT_EXIT_SOURCE.LOGOUT }),
     ).toMatchObject({
       date: vi.getMockedSystemTime()?.toISOString(),
       source: 'logout',
@@ -45,7 +45,7 @@ describe('compute telemetry events', () => {
       computeNewPageEvent({
         page: 'my-new-page',
         pageTag: 'my-page-tag',
-      })
+      }),
     ).toMatchObject({
       date: vi.getMockedSystemTime()?.toISOString(),
       page: 'my-new-page',
@@ -59,7 +59,7 @@ describe('compute telemetry events', () => {
       computeInputEvent({
         name: 'my-name',
         iteration: [1],
-      })
+      }),
     ).toMatchObject({
       date: vi.getMockedSystemTime()?.toISOString(),
       iteration: [1],
@@ -70,7 +70,7 @@ describe('compute telemetry events', () => {
 
   test('for control', () => {
     expect(
-      computeControlEvent({ controlIds: ['my-control-1', 'my-control-2'] })
+      computeControlEvent({ controlIds: ['my-control-1', 'my-control-2'] }),
     ).toMatchObject({
       controlIds: ['my-control-1', 'my-control-2'],
       date: vi.getMockedSystemTime()?.toISOString(),
@@ -80,7 +80,7 @@ describe('compute telemetry events', () => {
 
   test('for control skip', () => {
     expect(
-      computeControlSkipEvent({ controlIds: ['my-control-1', 'my-control-2'] })
+      computeControlSkipEvent({ controlIds: ['my-control-1', 'my-control-2'] }),
     ).toMatchObject({
       controlIds: ['my-control-1', 'my-control-2'],
       date: vi.getMockedSystemTime()?.toISOString(),
@@ -100,32 +100,32 @@ test('correctly compares input paradata', async () => {
   expect(
     areInputParadataIdentical(
       computeInputEvent({ name: 'name' }),
-      computeInputEvent({ name: 'name' })
-    )
+      computeInputEvent({ name: 'name' }),
+    ),
   ).toBeTruthy()
   expect(
     areInputParadataIdentical(
       computeInputEvent({ name: 'name1' }),
-      computeInputEvent({ name: 'name2' })
-    )
+      computeInputEvent({ name: 'name2' }),
+    ),
   ).toBeFalsy()
   expect(
     areInputParadataIdentical(
       computeInputEvent({ name: 'name', iteration: [1] }),
-      computeInputEvent({ name: 'name', iteration: [1] })
-    )
+      computeInputEvent({ name: 'name', iteration: [1] }),
+    ),
   ).toBeTruthy()
   expect(
     areInputParadataIdentical(
       computeInputEvent({ name: 'name1', iteration: [1] }),
-      computeInputEvent({ name: 'name2', iteration: [1] })
-    )
+      computeInputEvent({ name: 'name2', iteration: [1] }),
+    ),
   ).toBeFalsy()
   expect(
     areInputParadataIdentical(
       computeInputEvent({ name: 'name', iteration: [1] }),
-      computeInputEvent({ name: 'name', iteration: [2] })
-    )
+      computeInputEvent({ name: 'name', iteration: [2] }),
+    ),
   ).toBeFalsy()
   expect(
     areInputParadataIdentical(
@@ -133,7 +133,7 @@ test('correctly compares input paradata', async () => {
         name: 'name',
         iteration: undefined,
       }),
-      computeInputEvent({ name: 'name', iteration: [1] })
-    )
+      computeInputEvent({ name: 'name', iteration: [1] }),
+    ),
   ).toBeFalsy()
 })

--- a/src/utils/telemetry.ts
+++ b/src/utils/telemetry.ts
@@ -101,7 +101,7 @@ export function computeContactSupportEvent(): TelemetryParadata {
 
 export function areInputParadataIdentical(
   event1: InputParadata,
-  event2: InputParadata
+  event2: InputParadata,
 ): boolean {
   return (
     (event1.name === event2.name &&

--- a/src/utils/tests.tsx
+++ b/src/utils/tests.tsx
@@ -5,6 +5,6 @@ import { render } from '@testing-library/react'
 export const renderWithRouter = (component: React.ReactElement) => {
   return render(
     // @ts-expect-error: we should have a better router mock
-    <RouterProvider router={router} defaultComponent={() => component} />
+    <RouterProvider router={router} defaultComponent={() => component} />,
   )
 }

--- a/src/utils/useEvent.ts
+++ b/src/utils/useEvent.ts
@@ -14,6 +14,6 @@ export function useEvent<
   return useState(
     () =>
       (...args: Parameters<Exclude<T, undefined | null>>) =>
-        callbackRef.current(...args)
+        callbackRef.current(...args),
   )[0] as T
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -16,8 +16,8 @@ type ImportMetaEnv = {
   MODE: string
   DEV: boolean
   PROD: boolean
-  APP_VERSION: string
-  LUNATIC_VERSION: string
+  APP_VERSION: any
+  LUNATIC_VERSION: any
   // @user-defined-start
   /*
    * Here you can define your own special variables

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,14 +23,5 @@ export default defineConfig(({ mode }) => {
         }),
       }),
     ],
-    test: {
-      globals: true,
-      environment: 'jsdom',
-      include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-      setupFiles: 'tests/setup.ts',
-      coverage: {
-        reporter: ['text', 'lcov'],
-      },
-    },
   }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from 'vitest/config'
+
+import viteConfig from './vite.config'
+
+// https://vitest.dev/config/file.html
+export default defineConfig((configEnv) =>
+  mergeConfig(
+    viteConfig(configEnv),
+    defineConfig({
+      test: {
+        globals: true,
+        environment: 'jsdom',
+        include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+        setupFiles: 'tests/setup.ts',
+        coverage: {
+          reporter: ['text', 'lcov'],
+        },
+      },
+    }),
+  ),
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1974,6 +1974,13 @@ ansi-colors@^4.1.1:
   resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
+ansi-escapes@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.0.0.tgz#00fc19f491bbb18e1d481b97868204f92109bfe7"
+  integrity sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==
+  dependencies:
+    environment "^1.0.0"
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
@@ -2003,7 +2010,7 @@ ansi-styles@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-ansi-styles@^6.1.0:
+ansi-styles@^6.0.0, ansi-styles@^6.1.0, ansi-styles@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -2250,6 +2257,11 @@ chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
@@ -2300,6 +2312,21 @@ classnames@^2.3.0, classnames@^2.5.1:
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
 
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
+  dependencies:
+    restore-cursor "^5.0.0"
+
+cli-truncate@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-4.0.0.tgz#6cc28a2924fee9e25ce91e973db56c7066e6172a"
+  integrity sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^7.0.0"
+
 cliui@^8.0.1:
   version "8.0.1"
   resolved "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz"
@@ -2343,6 +2370,11 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
@@ -2354,6 +2386,11 @@ comma-separated-tokens@^2.0.0:
   version "2.0.3"
   resolved "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz"
   integrity sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==
+
+commander@~12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 compare-versions@^6.1.0:
   version "6.1.0"
@@ -2485,7 +2522,7 @@ dayjs@^1.8.12:
   resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz"
   integrity sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg==
 
-debug@4, debug@^4.3.6:
+debug@4, debug@^4.3.6, debug@~4.3.6:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.7.tgz#87945b4151a011d76d95a198d7111c865c360a52"
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
@@ -2629,6 +2666,11 @@ electron-to-chromium@^1.4.796:
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz"
   integrity sha512-EKH5X5oqC6hLmiS7/vYtZHZFTNdhsYG5NVPRN6Yn0kQHNBlT59+xSM8HBy66P5fxWpKgZbPqb+diC64ng295Jw==
 
+emoji-regex@^10.3.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.4.0.tgz#03553afea80b3975749cfcb36f776ca268e413d4"
+  integrity sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -2661,6 +2703,11 @@ entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -3068,6 +3115,11 @@ eventemitter3@^4.0.0:
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+eventemitter3@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
+  integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
+
 evt@^2.5.7:
   version "2.5.7"
   resolved "https://registry.npmjs.org/evt/-/evt-2.5.7.tgz"
@@ -3091,6 +3143,21 @@ execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
+
+execa@~8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-8.0.1.tgz#51f6a5943b580f963c3ca9c6321796db8cc39b8c"
+  integrity sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^8.0.1"
+    human-signals "^5.0.0"
+    is-stream "^3.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^5.1.0"
+    onetime "^6.0.0"
+    signal-exit "^4.1.0"
+    strip-final-newline "^3.0.0"
 
 ext@^1.7.0:
   version "1.7.0"
@@ -3260,6 +3327,11 @@ get-caller-file@^2.0.5:
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-east-asian-width@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz#21b4071ee58ed04ee0db653371b55b4299875389"
+  integrity sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==
+
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz"
@@ -3275,6 +3347,11 @@ get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
+
+get-stream@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-8.0.1.tgz#def9dfd71742cd7754a7761ed43749a27d02eca2"
+  integrity sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==
 
 get-symbol-description@^1.0.2:
   version "1.0.2"
@@ -3544,6 +3621,11 @@ human-signals@^2.1.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+human-signals@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-5.0.0.tgz#42665a284f9ae0dade3ba41ebc37eb4b852f3a28"
+  integrity sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==
+
 husky@^9.1.6:
   version "9.1.6"
   resolved "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz"
@@ -3700,6 +3782,18 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
+is-fullwidth-code-point@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz#9609efced7c2f97da7b60145ef481c787c7ba704"
+  integrity sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==
+  dependencies:
+    get-east-asian-width "^1.0.0"
+
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
@@ -3768,6 +3862,11 @@ is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
+is-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
+  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
 
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
@@ -3983,10 +4082,43 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lilconfig@~3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-3.1.2.tgz#e4a7c3cb549e3a606c8dcc32e5ae1005e62c05cb"
+  integrity sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+lint-staged@^15.2.10:
+  version "15.2.10"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-15.2.10.tgz#92ac222f802ba911897dcf23671da5bb80643cd2"
+  integrity sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==
+  dependencies:
+    chalk "~5.3.0"
+    commander "~12.1.0"
+    debug "~4.3.6"
+    execa "~8.0.1"
+    lilconfig "~3.1.2"
+    listr2 "~8.2.4"
+    micromatch "~4.0.8"
+    pidtree "~0.6.0"
+    string-argv "~0.3.2"
+    yaml "~2.5.0"
+
+listr2@~8.2.4:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-8.2.5.tgz#5c9db996e1afeb05db0448196d3d5f64fec2593d"
+  integrity sha512-iyAZCeyD+c1gPyE9qpFu8af0Y+MRtmKOncdGoA2S5EY8iFq99dmmvkNnHiWo+pj0s7yH7l3KPIgee77tKpXPWQ==
+  dependencies:
+    cli-truncate "^4.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -4044,6 +4176,17 @@ lodash@^4.17.14, lodash@^4.17.21, lodash@~4.17.21:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
+  dependencies:
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 loglevel-plugin-prefix@0.8.4:
   version "0.8.4"
@@ -4468,6 +4611,14 @@ micromatch@^4.0.4, micromatch@^4.0.5:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+micromatch@~4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
@@ -4489,6 +4640,16 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+mimic-fn@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
+  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
+
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -4629,6 +4790,13 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npm-run-path@^5.1.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.3.0.tgz#e23353d0ebb9317f174e93417e4a4d82d0249e9f"
+  integrity sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==
+  dependencies:
+    path-key "^4.0.0"
+
 numeral@^2.0.6:
   version "2.0.6"
   resolved "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz"
@@ -4721,6 +4889,20 @@ onetime@^5.1.2:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+onetime@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
+  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
+  dependencies:
+    mimic-fn "^4.0.0"
+
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
 
 openapi3-ts@4.2.2:
   version "4.2.2"
@@ -4853,6 +5035,11 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
+path-key@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
+  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
+
 path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz"
@@ -4895,6 +5082,11 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+
+pidtree@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.6.0.tgz#90ad7b6d42d5841e69e0a2419ef38f8883aa057c"
+  integrity sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==
 
 pony-cause@^1.0.0:
   version "1.1.1"
@@ -5198,10 +5390,23 @@ resolve@^1.19.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
+  dependencies:
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rollup@^4.20.0:
   version "4.21.0"
@@ -5422,7 +5627,7 @@ signal-exit@^3.0.3:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^4.0.1:
+signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
@@ -5445,6 +5650,22 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
+
+slice-ansi@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.0.tgz#cd6b4655e298a8d1bdeb04250a433094b347b9a9"
+  integrity sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==
+  dependencies:
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
 
 "source-map-js@>=0.6.2 <2.0.0":
   version "1.2.0"
@@ -5481,7 +5702,7 @@ std-env@^3.7.0:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.7.0.tgz#c9f7386ced6ecf13360b6c6c55b8aaa4ef7481d2"
   integrity sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==
 
-string-argv@^0.3.2:
+string-argv@^0.3.2, string-argv@~0.3.2:
   version "0.3.2"
   resolved "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
@@ -5512,6 +5733,15 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
 
 string.prototype.trim@^1.2.9:
   version "1.2.9"
@@ -5563,7 +5793,7 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@^7.0.1:
+strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
@@ -5574,6 +5804,11 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+
+strip-final-newline@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
+  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
 
 strip-indent@^3.0.0:
   version "3.0.0"
@@ -6210,6 +6445,15 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
+wrap-ansi@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.0.tgz#1a3dc8b70d85eeb8398ddfb1e4a02cd186e58b3e"
+  integrity sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
+
 ws@^8.18.0:
   version "8.18.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
@@ -6244,6 +6488,11 @@ yaml@^2.3.4, yaml@^2.4.5:
   version "2.4.5"
   resolved "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz"
   integrity sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==
+
+yaml@~2.5.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.5.1.tgz#c9772aacf62cb7494a95b0c4f1fb065b563db130"
+  integrity sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
* Updated `.prettierrc` by removing values that were the same as the default.
Except for `"trailingComma": "es5",` which becomes `"always"` now (which allow for a better git logging when one adds a new value on a list).

* Added `lint-staged` configuration for `eslint` and `prettier`