### PR TITLE
chore: remove generated files from Sonar coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,14 +7,13 @@ sonar.projectVersion=1.0
 
 # Path to sources
 sonar.sources=src
-sonar.exclusions=**/*.test.js, **/*.test.jsx, **/*.test.ts, **/*.test.tsx
+sonar.exclusions=**/*.test.js, **/*.test.jsx, **/*.test.ts, **/*.test.tsx, src/api/*-*.ts, src/models/api/*
 
 # Path to tests
 sonar.test.inclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src/**/*.test.tsx
 
 # Coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.coverage.exclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src/**/*.test.tsx, src/api/*-*.ts, src/models/api/*
 
 # Source encoding
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,7 @@ sonar.test.inclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src
 
 # Coverage
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.coverage.exclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src/**/*.test.tsx
+sonar.coverage.exclusions=src/**/*.test.js, src/**/*.test.jsx, src/**/*.test.ts, src/**/*.test.tsx, src/api/*-*.ts, src/models/api/*
 
 # Source encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Removed orval generated files so that computed coverage better reflect our code quality.