### PR TITLE
style: adaptive suggester width

### DIFF
--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -42,6 +42,7 @@ import { usePushEventAfterInactivity } from './hooks/usePushEventAfterInactivity
 import { useRefSync } from './hooks/useRefSync'
 import { useStromaeNavigation } from './hooks/useStromaeNavigation'
 import { useUpdateEffect } from './hooks/useUpdateEffect'
+import './orchestrator.css'
 import { slotComponents } from './slotComponents'
 import { computeLunaticComponents } from './utils/components'
 import { isBlockingError } from './utils/controls'

--- a/src/components/orchestrator/orchestrator.css
+++ b/src/components/orchestrator/orchestrator.css
@@ -1,0 +1,4 @@
+/* Adapt suggester popper width in table. Should be handled by Lunatic-dsfr. */
+.fr-table .field .MuiAutocomplete-popper {
+  min-width: fit-content;
+}


### PR DESCRIPTION
Adapt suggester popper width inside table.

Since we had issues doing in Lunatic-dsfr by updating the component (did work in Lunatic-dsfr but then we lost style in Stromae), this is a short term solution...