### PR TITLE
feat: expand container by default for sequence pagination

### DIFF
--- a/src/components/orchestrator/SurveyContainer.tsx
+++ b/src/components/orchestrator/SurveyContainer.tsx
@@ -49,7 +49,9 @@ export function SurveyContainer(
     currentPage,
   )
 
-  const [isLayoutExpanded, setIsLayoutExpanded] = useState<boolean>(false)
+  const [isLayoutExpanded, setIsLayoutExpanded] = useState<boolean>(
+    pagination === 'sequence',
+  )
 
   const displaySequenceHeader =
     !isSequencePage && currentPage === PAGE_TYPE.LUNATIC


### PR DESCRIPTION
expand survey container by default for sequence pagination (remind : button for expanding is only displayed on sequence pagination)