### PR TITLE
fix: compile controls only on lunatic pages

### DIFF
--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -197,30 +197,31 @@ export function Orchestrator(props: OrchestratorProps) {
     surveyUnitData?.stateData?.date,
   )
 
-  const { currentPage, goNext, goToPage, goPrevious } = useStromaeNavigation({
-    goNextLunatic: goNextLunaticPage,
-    goPrevLunatic: goPreviousLunaticPage,
-    goToLunaticPage: goToLunaticPage,
-    isFirstPage,
-    isLastPage,
-    initialCurrentPage,
-    openValidationModal: () => validationModalActionsRef.current.open(),
-  })
-
   const {
     activeErrors,
-    handleGoToPage,
-    handleNextPage,
-    handlePreviousPage,
+    handleGoToLunaticPage,
+    handleNextLunaticPage,
+    handlePreviousLunaticPage,
     resetControls,
   } = useControls({
     compileControls,
     pushEvent,
     isTelemetryInitialized,
-    goNextPage: goNext,
-    goPreviousPage: goPrevious,
-    goToPage: goToPage,
+    goNextPage: goNextLunaticPage,
+    goPreviousPage: goPreviousLunaticPage,
+    goToPage: goToLunaticPage,
   })
+
+  const { currentPage, handleNextPage, handleGoToPage, handlePreviousPage } =
+    useStromaeNavigation({
+      goNextLunatic: handleNextLunaticPage,
+      goPrevLunatic: handlePreviousLunaticPage,
+      goToLunaticPage: handleGoToLunaticPage,
+      isFirstPage,
+      isLastPage,
+      initialCurrentPage,
+      openValidationModal: () => validationModalActionsRef.current.open(),
+    })
 
   const previousPage = usePrevious(currentPage) ?? initialCurrentPage
   const previousPageTag = usePrevious(pageTag) ?? initialCurrentPage

--- a/src/components/orchestrator/hooks/useControls/useControls.ts
+++ b/src/components/orchestrator/hooks/useControls/useControls.ts
@@ -2,25 +2,27 @@ import { useState } from 'react'
 
 import type { LunaticError, LunaticState } from '@inseefr/lunatic'
 
+import type {
+  LunaticGoNextPage,
+  LunaticGoPreviousPage,
+  LunaticGoToPage,
+} from '@/models/lunaticType'
 import type { TelemetryParadata } from '@/models/telemetry'
 import { computeControlEvent, computeControlSkipEvent } from '@/utils/telemetry'
 
-import { useStromaeNavigation } from '../useStromaeNavigation'
 import { ErrorType, computeErrorType, isSameErrors } from './utils'
 
 type useControlsProps = {
   compileControls: LunaticState['compileControls']
-  goNextPage: () => void
-  goPreviousPage: () => void
-  goToPage: (
-    page: Parameters<ReturnType<typeof useStromaeNavigation>['goToPage']>[0],
-  ) => void
+  goNextPage: LunaticGoNextPage
+  goPreviousPage: LunaticGoPreviousPage
+  goToPage: LunaticGoToPage
   isTelemetryInitialized?: boolean
   pushEvent: (e: TelemetryParadata) => void | Promise<boolean>
 }
 
 /**
- * On navigation, compute controls from filled inputs.
+ * On navigation in a Lunatic page, compute controls from filled inputs.
  *
  * It will return what is necessary to display the errors and block the user if
  * the error is blocking.
@@ -40,7 +42,7 @@ export function useControls({
   const [isWarningAcknowledged, setIsWarningAcknowledged] =
     useState<boolean>(false)
 
-  const handleNextPage = () => {
+  const handleNextLunaticPage = () => {
     const { currentErrors } = compileControls()
 
     const errorType = computeErrorType(currentErrors)
@@ -94,14 +96,12 @@ export function useControls({
     }
   }
 
-  const handlePreviousPage = () => {
+  const handlePreviousLunaticPage = () => {
     resetControls()
     goPreviousPage()
   }
 
-  const handleGoToPage = (
-    page: Parameters<ReturnType<typeof useStromaeNavigation>['goToPage']>[0],
-  ) => {
+  const handleGoToLunaticPage = (page: Parameters<LunaticGoToPage>[0]) => {
     resetControls()
     goToPage(page)
   }
@@ -116,11 +116,11 @@ export function useControls({
     /** Errors to be displayed by Lunatic components (sorted by criticality). */
     activeErrors,
     /** Go to page handler which reset controls (e.g. active errors). */
-    handleGoToPage,
+    handleGoToLunaticPage,
     /** Go to next page handler which check controls shenanigans. */
-    handleNextPage,
+    handleNextLunaticPage,
     /** Go to previous page handler which reset controls (e.g. active errors). */
-    handlePreviousPage,
+    handlePreviousLunaticPage,
     /**
      * Whether or not the respondent should be blocked from further navigation
      * until the filled input is changed. Should be used to set navigation

--- a/src/components/orchestrator/hooks/useStromaeNavigation.test.tsx
+++ b/src/components/orchestrator/hooks/useStromaeNavigation.test.tsx
@@ -20,7 +20,7 @@ describe('Use stromae navigation', () => {
         }),
       )
 
-      act(() => result.current.goNext())
+      act(() => result.current.handleNextPage())
 
       expect(result.current.currentPage).toBe(expected)
     },
@@ -37,9 +37,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.goNext()) // go to lunatic page
+    act(() => result.current.handleNextPage()) // go to lunatic page
 
-    act(() => result.current.goNext())
+    act(() => result.current.handleNextPage())
 
     expect(goNextLunaticMock).toHaveBeenCalledOnce()
     expect(result.current.currentPage).toBe(PAGE_TYPE.LUNATIC)
@@ -57,9 +57,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.goNext()) // go to lunatic page
+    act(() => result.current.handleNextPage()) // go to lunatic page
 
-    act(() => result.current.goNext())
+    act(() => result.current.handleNextPage())
 
     expect(goNextLunaticMock).not.toHaveBeenCalled()
     expect(result.current.currentPage).toBe(PAGE_TYPE.VALIDATION)
@@ -79,7 +79,7 @@ describe('Use stromae navigation', () => {
         }),
       )
 
-      act(() => result.current.goPrevious())
+      act(() => result.current.handlePreviousPage())
 
       expect(result.current.currentPage).toBe(expected)
     },
@@ -94,9 +94,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.goNext()) // go to lunatic page
+    act(() => result.current.handleNextPage()) // go to lunatic page
 
-    act(() => result.current.goPrevious())
+    act(() => result.current.handlePreviousPage())
 
     expect(goPrevLunaticMock).toHaveBeenCalledOnce()
     expect(result.current.currentPage).toBe(PAGE_TYPE.LUNATIC)
@@ -112,9 +112,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.goNext()) // go to lunatic page
+    act(() => result.current.handleNextPage()) // go to lunatic page
 
-    act(() => result.current.goPrevious())
+    act(() => result.current.handlePreviousPage())
 
     expect(goPrevLunaticMock).not.toHaveBeenCalled()
     expect(result.current.currentPage).toBe(PAGE_TYPE.WELCOME)
@@ -133,7 +133,7 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.goToPage({ page }))
+    act(() => result.current.handleGoToPage({ page }))
     expect(goToLunaticPageMock).not.toHaveBeenCalled()
 
     expect(result.current.currentPage).toBe(page)
@@ -148,7 +148,7 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.goToPage({ page: 1 }))
+    act(() => result.current.handleGoToPage({ page: 1 }))
 
     expect(goToLunaticPageMock).toHaveBeenCalledOnce()
     expect(goToLunaticPageMock).toHaveBeenCalledWith({ page: 1 })

--- a/src/components/orchestrator/hooks/useStromaeNavigation.tsx
+++ b/src/components/orchestrator/hooks/useStromaeNavigation.tsx
@@ -35,7 +35,7 @@ export function useStromaeNavigation({
     initialCurrentPage === PAGE_TYPE.END ? PAGE_TYPE.END : PAGE_TYPE.WELCOME,
   )
 
-  const goNext = () => {
+  const handleNextPage = () => {
     switch (currentPage) {
       case PAGE_TYPE.VALIDATION:
         openValidationModal().then(() => {
@@ -53,7 +53,7 @@ export function useStromaeNavigation({
     }
   }
 
-  const goPrevious = () => {
+  const handlePreviousPage = () => {
     switch (currentPage) {
       case PAGE_TYPE.VALIDATION:
         return setCurrentPage(PAGE_TYPE.LUNATIC)
@@ -65,7 +65,7 @@ export function useStromaeNavigation({
     }
   }
 
-  const goToPage = (
+  const handleGoToPage = (
     params:
       | {
           page: StromaePage
@@ -84,5 +84,5 @@ export function useStromaeNavigation({
         goToLunaticPage(params)
     }
   }
-  return { goNext, goPrevious, goToPage, currentPage }
+  return { handleNextPage, handlePreviousPage, handleGoToPage, currentPage }
 }


### PR DESCRIPTION
Since https://github.com/InseeFr/stromae-dsfr/pull/210 (refactor handling controls like in Drama-Queen with the useControls), we always compiled controls even if we are not in a lunatic page.

Indeed, the process must be : 
- we override lunatic navigation functions for handling controls
- we handle the final navigation functions, using either lunatic (overrired with controls) functions or other functions, depending on the current page (welcome, lunatic, validation, end)


Compiling the controls on the introduction page took the controls of page 1 (default in Lunatic), so in pagination=sequence if there are controls in the 1st sequence (=page 1), they were triggered wrongly