### PR TITLE
fix: controls only on lunatic pages

### DIFF
--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -197,31 +197,30 @@ export function Orchestrator(props: OrchestratorProps) {
     surveyUnitData?.stateData?.date,
   )
 
+  const { currentPage, goNext, goToPage, goPrevious } = useStromaeNavigation({
+    goNextLunatic: goNextLunaticPage,
+    goPrevLunatic: goPreviousLunaticPage,
+    goToLunaticPage: goToLunaticPage,
+    isFirstPage,
+    isLastPage,
+    initialCurrentPage,
+    openValidationModal: () => validationModalActionsRef.current.open(),
+  })
+
   const {
     activeErrors,
-    handleGoToLunaticPage,
-    handleNextLunaticPage,
-    handlePreviousLunaticPage,
+    handleGoToPage,
+    handleNextPage,
+    handlePreviousPage,
     resetControls,
   } = useControls({
     compileControls,
     pushEvent,
     isTelemetryInitialized,
-    goNextPage: goNextLunaticPage,
-    goPreviousPage: goPreviousLunaticPage,
-    goToPage: goToLunaticPage,
+    goNextPage: goNext,
+    goPreviousPage: goPrevious,
+    goToPage: goToPage,
   })
-
-  const { currentPage, handleNextPage, handleGoToPage, handlePreviousPage } =
-    useStromaeNavigation({
-      goNextLunatic: handleNextLunaticPage,
-      goPrevLunatic: handlePreviousLunaticPage,
-      goToLunaticPage: handleGoToLunaticPage,
-      isFirstPage,
-      isLastPage,
-      initialCurrentPage,
-      openValidationModal: () => validationModalActionsRef.current.open(),
-    })
 
   const previousPage = usePrevious(currentPage) ?? initialCurrentPage
   const previousPageTag = usePrevious(pageTag) ?? initialCurrentPage

--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -395,7 +395,9 @@ export function Orchestrator(props: OrchestratorProps) {
     <div ref={containerRef}>
       <LunaticProvider>
         <SurveyContainer
-          handleNextClick={handleNextPage}
+          handleNextClick={() =>
+            handleNextPage(currentPage === PAGE_TYPE.LUNATIC)
+          }
           handlePreviousClick={handlePreviousPage}
           handleDownloadData={downloadAsJsonRef.current} // Visualize
           currentPage={currentPage}

--- a/src/components/orchestrator/hooks/useControls/useControls.ts
+++ b/src/components/orchestrator/hooks/useControls/useControls.ts
@@ -2,27 +2,25 @@ import { useState } from 'react'
 
 import type { LunaticError, LunaticState } from '@inseefr/lunatic'
 
-import type {
-  LunaticGoNextPage,
-  LunaticGoPreviousPage,
-  LunaticGoToPage,
-} from '@/models/lunaticType'
 import type { TelemetryParadata } from '@/models/telemetry'
 import { computeControlEvent, computeControlSkipEvent } from '@/utils/telemetry'
 
+import { useStromaeNavigation } from '../useStromaeNavigation'
 import { ErrorType, computeErrorType, isSameErrors } from './utils'
 
 type useControlsProps = {
   compileControls: LunaticState['compileControls']
-  goNextPage: LunaticGoNextPage
-  goPreviousPage: LunaticGoPreviousPage
-  goToPage: LunaticGoToPage
+  goNextPage: () => void
+  goPreviousPage: () => void
+  goToPage: (
+    page: Parameters<ReturnType<typeof useStromaeNavigation>['goToPage']>[0],
+  ) => void
   isTelemetryInitialized?: boolean
   pushEvent: (e: TelemetryParadata) => void | Promise<boolean>
 }
 
 /**
- * On navigation in a Lunatic page, compute controls from filled inputs.
+ * On navigation, compute controls from filled inputs.
  *
  * It will return what is necessary to display the errors and block the user if
  * the error is blocking.
@@ -42,7 +40,7 @@ export function useControls({
   const [isWarningAcknowledged, setIsWarningAcknowledged] =
     useState<boolean>(false)
 
-  const handleNextLunaticPage = () => {
+  const handleNextPage = () => {
     const { currentErrors } = compileControls()
 
     const errorType = computeErrorType(currentErrors)
@@ -96,12 +94,14 @@ export function useControls({
     }
   }
 
-  const handlePreviousLunaticPage = () => {
+  const handlePreviousPage = () => {
     resetControls()
     goPreviousPage()
   }
 
-  const handleGoToLunaticPage = (page: Parameters<LunaticGoToPage>[0]) => {
+  const handleGoToPage = (
+    page: Parameters<ReturnType<typeof useStromaeNavigation>['goToPage']>[0],
+  ) => {
     resetControls()
     goToPage(page)
   }
@@ -116,11 +116,11 @@ export function useControls({
     /** Errors to be displayed by Lunatic components (sorted by criticality). */
     activeErrors,
     /** Go to page handler which reset controls (e.g. active errors). */
-    handleGoToLunaticPage,
+    handleGoToPage,
     /** Go to next page handler which check controls shenanigans. */
-    handleNextLunaticPage,
+    handleNextPage,
     /** Go to previous page handler which reset controls (e.g. active errors). */
-    handlePreviousLunaticPage,
+    handlePreviousPage,
     /**
      * Whether or not the respondent should be blocked from further navigation
      * until the filled input is changed. Should be used to set navigation

--- a/src/components/orchestrator/hooks/useControls/useControls.ts
+++ b/src/components/orchestrator/hooks/useControls/useControls.ts
@@ -40,7 +40,9 @@ export function useControls({
   const [isWarningAcknowledged, setIsWarningAcknowledged] =
     useState<boolean>(false)
 
-  const handleNextPage = () => {
+  const handleNextPage = (isOnLunaticPage: boolean) => {
+    if (!isOnLunaticPage) return goNextPage()
+
     const { currentErrors } = compileControls()
 
     const errorType = computeErrorType(currentErrors)

--- a/src/components/orchestrator/hooks/useStromaeNavigation.test.tsx
+++ b/src/components/orchestrator/hooks/useStromaeNavigation.test.tsx
@@ -20,7 +20,7 @@ describe('Use stromae navigation', () => {
         }),
       )
 
-      act(() => result.current.handleNextPage())
+      act(() => result.current.goNext())
 
       expect(result.current.currentPage).toBe(expected)
     },
@@ -37,9 +37,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.handleNextPage()) // go to lunatic page
+    act(() => result.current.goNext()) // go to lunatic page
 
-    act(() => result.current.handleNextPage())
+    act(() => result.current.goNext())
 
     expect(goNextLunaticMock).toHaveBeenCalledOnce()
     expect(result.current.currentPage).toBe(PAGE_TYPE.LUNATIC)
@@ -57,9 +57,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.handleNextPage()) // go to lunatic page
+    act(() => result.current.goNext()) // go to lunatic page
 
-    act(() => result.current.handleNextPage())
+    act(() => result.current.goNext())
 
     expect(goNextLunaticMock).not.toHaveBeenCalled()
     expect(result.current.currentPage).toBe(PAGE_TYPE.VALIDATION)
@@ -79,7 +79,7 @@ describe('Use stromae navigation', () => {
         }),
       )
 
-      act(() => result.current.handlePreviousPage())
+      act(() => result.current.goPrevious())
 
       expect(result.current.currentPage).toBe(expected)
     },
@@ -94,9 +94,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.handleNextPage()) // go to lunatic page
+    act(() => result.current.goNext()) // go to lunatic page
 
-    act(() => result.current.handlePreviousPage())
+    act(() => result.current.goPrevious())
 
     expect(goPrevLunaticMock).toHaveBeenCalledOnce()
     expect(result.current.currentPage).toBe(PAGE_TYPE.LUNATIC)
@@ -112,9 +112,9 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.handleNextPage()) // go to lunatic page
+    act(() => result.current.goNext()) // go to lunatic page
 
-    act(() => result.current.handlePreviousPage())
+    act(() => result.current.goPrevious())
 
     expect(goPrevLunaticMock).not.toHaveBeenCalled()
     expect(result.current.currentPage).toBe(PAGE_TYPE.WELCOME)
@@ -133,7 +133,7 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.handleGoToPage({ page }))
+    act(() => result.current.goToPage({ page }))
     expect(goToLunaticPageMock).not.toHaveBeenCalled()
 
     expect(result.current.currentPage).toBe(page)
@@ -148,7 +148,7 @@ describe('Use stromae navigation', () => {
       }),
     )
 
-    act(() => result.current.handleGoToPage({ page: 1 }))
+    act(() => result.current.goToPage({ page: 1 }))
 
     expect(goToLunaticPageMock).toHaveBeenCalledOnce()
     expect(goToLunaticPageMock).toHaveBeenCalledWith({ page: 1 })

--- a/src/components/orchestrator/hooks/useStromaeNavigation.tsx
+++ b/src/components/orchestrator/hooks/useStromaeNavigation.tsx
@@ -35,7 +35,7 @@ export function useStromaeNavigation({
     initialCurrentPage === PAGE_TYPE.END ? PAGE_TYPE.END : PAGE_TYPE.WELCOME,
   )
 
-  const handleNextPage = () => {
+  const goNext = () => {
     switch (currentPage) {
       case PAGE_TYPE.VALIDATION:
         openValidationModal().then(() => {
@@ -53,7 +53,7 @@ export function useStromaeNavigation({
     }
   }
 
-  const handlePreviousPage = () => {
+  const goPrevious = () => {
     switch (currentPage) {
       case PAGE_TYPE.VALIDATION:
         return setCurrentPage(PAGE_TYPE.LUNATIC)
@@ -65,7 +65,7 @@ export function useStromaeNavigation({
     }
   }
 
-  const handleGoToPage = (
+  const goToPage = (
     params:
       | {
           page: StromaePage
@@ -84,5 +84,5 @@ export function useStromaeNavigation({
         goToLunaticPage(params)
     }
   }
-  return { handleNextPage, handlePreviousPage, handleGoToPage, currentPage }
+  return { goNext, goPrevious, goToPage, currentPage }
 }


### PR DESCRIPTION
revert what has been done on https://github.com/InseeFr/stromae-dsfr/pull/211 , since controls were not triggered on the last lunatic page.

Instead of updating the functions, trigger controls only if the current page is a Lunatic page