### PR TITLE
feat: add dsfr white label config

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,6 @@ VITE_TELEMETRY_DISABLED=
 VITE_TELEMETRY_MAX_DELAY=
 # Override max number of data to send in a single batch (default: 10)
 VITE_TELEMETRY_MAX_LENGTH=
+
+# When VITE_IS_GOV_INSTANCE equals true we use the dsfr design and false we use the default design cf https://react-dsfr.codegouv.studio/custom-branding
+VITE_IS_GOV_INSTANCE=

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "prebuild-storybook": "react-dsfr update-icons"
   },
   "dependencies": {
-    "@codegouvfr/react-dsfr": "^1.13.6",
+    "@codegouvfr/react-dsfr": "^1.23.4",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@inseefr/lunatic": "^3.5.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import { MuiDsfrThemeProvider } from '@codegouvfr/react-dsfr/mui'
+import { createDsfrCustomBrandingProvider } from '@codegouvfr/react-dsfr/mui'
 import { startReactDsfr } from '@codegouvfr/react-dsfr/spa'
+import { createTheme } from '@mui/material/styles'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import {
   Link,
@@ -8,6 +9,7 @@ import {
   createRouter,
 } from '@tanstack/react-router'
 
+import logoInseePngUrl from '@/assets/logo-insee.png'
 import { TelemetryProvider } from '@/contexts/TelemetryContext'
 import { OidcProvider } from '@/oidc'
 import { routeTree } from '@/router/router'
@@ -15,6 +17,31 @@ import { routeTree } from '@/router/router'
 startReactDsfr({
   defaultColorScheme: 'system',
   Link,
+})
+
+const { DsfrCustomBrandingProvider } = createDsfrCustomBrandingProvider({
+  createMuiTheme: ({ isDark, theme_gov }) => {
+    if (import.meta.env.VITE_IS_GOV_INSTANCE === 'true') {
+      return { theme: theme_gov }
+    }
+
+    const theme = createTheme({
+      palette: {
+        mode: isDark ? 'dark' : 'light',
+        primary: {
+          main: isDark ? '#02AFFF' : '#3467AE',
+        },
+        secondary: {
+          main: '#FFC403',
+        },
+      },
+      typography: {
+        fontFamily: '"Geist"',
+      },
+    })
+
+    return { theme, faviconUrl: logoInseePngUrl }
+  },
 })
 
 declare module '@codegouvfr/react-dsfr/spa' {
@@ -48,7 +75,7 @@ declare module '@tanstack/react-router' {
 /** Wraps and inits the providers used in the app */
 export function App() {
   return (
-    <MuiDsfrThemeProvider>
+    <DsfrCustomBrandingProvider>
       <QueryClientProvider client={queryClient}>
         <OidcProvider>
           <TelemetryProvider>
@@ -59,6 +86,6 @@ export function App() {
           </TelemetryProvider>
         </OidcProvider>
       </QueryClientProvider>
-    </MuiDsfrThemeProvider>
+    </DsfrCustomBrandingProvider>
   )
 }

--- a/src/components/error/ErrorComponent.tsx
+++ b/src/components/error/ErrorComponent.tsx
@@ -1,12 +1,10 @@
 import { fr } from '@codegouvfr/react-dsfr'
 import Button from '@codegouvfr/react-dsfr/Button'
-import ArtWorkBackground from '@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg'
-import TechnicalError from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg'
-import ArtWork from '@codegouvfr/react-dsfr/dsfr/artwork/system.svg'
 import { useNavigate, useSearch } from '@tanstack/react-router'
 
 import { Container } from '@/components/Container'
 import { errorNormalizer } from '@/components/error/errorNormalizer'
+import { TechnicalError } from '@/components/pictogram/TechnicalError'
 import { useDocumentTitle } from '@/hooks/useDocumentTitle'
 import { declareComponentKeys, useTranslation } from '@/i18n'
 
@@ -73,38 +71,7 @@ export function ErrorComponent(props: Props) {
             'fr-unhidden-lg',
           )}
         >
-          <svg
-            className={fr.cx('fr-artwork', 'fr-responsive-img')}
-            aria-hidden="true"
-            width="160"
-            height="200"
-            viewBox="0 0 160 200"
-          >
-            <use
-              className={fr.cx('fr-artwork-motif')}
-              href={`${ArtWorkBackground}#artwork-motif`}
-            ></use>
-            <use href={`${ArtWork}#artwork-motif`}></use>
-
-            <use
-              className={fr.cx('fr-artwork-background')}
-              href={`${ArtWorkBackground}#artwork-background`}
-            ></use>
-            <g transform="translate(40, 60)">
-              <use
-                className={fr.cx('fr-artwork-decorative')}
-                xlinkHref={`${TechnicalError}#artwork-decorative`}
-              ></use>
-              <use
-                className={fr.cx('fr-artwork-minor')}
-                xlinkHref={`${TechnicalError}#artwork-minor`}
-              ></use>
-              <use
-                className={fr.cx('fr-artwork-major')}
-                xlinkHref={`${TechnicalError}#artwork-major`}
-              ></use>
-            </g>
-          </svg>
+          <TechnicalError />
         </div>
       </div>
     </Container>

--- a/src/components/pictogram/TechnicalError.tsx
+++ b/src/components/pictogram/TechnicalError.tsx
@@ -1,0 +1,57 @@
+import { fr } from '@codegouvfr/react-dsfr'
+import ArtWorkBackground from '@codegouvfr/react-dsfr/dsfr/artwork/background/ovoid.svg'
+import TechnicalErrorDsfr from '@codegouvfr/react-dsfr/dsfr/artwork/pictograms/system/technical-error.svg'
+import ArtWork from '@codegouvfr/react-dsfr/dsfr/artwork/system.svg'
+import { useIsGov } from '@codegouvfr/react-dsfr/mui'
+
+import computerErrorSvgUrl from './computer-error.svg'
+
+export function TechnicalError() {
+  const { isGov } = useIsGov()
+
+  if (!isGov) {
+    return (
+      <img
+        alt="technical-error"
+        aria-hidden="true"
+        src={computerErrorSvgUrl}
+        width="160"
+        height="200"
+      />
+    )
+  }
+  return (
+    <svg
+      className={fr.cx('fr-artwork', 'fr-responsive-img')}
+      aria-hidden="true"
+      width="160"
+      height="200"
+      viewBox="0 0 160 200"
+    >
+      <use
+        className={fr.cx('fr-artwork-motif')}
+        href={`${ArtWorkBackground}#artwork-motif`}
+      ></use>
+      <use href={`${ArtWork}#artwork-motif`}></use>
+
+      <use
+        className={fr.cx('fr-artwork-background')}
+        href={`${ArtWorkBackground}#artwork-background`}
+      ></use>
+      <g transform="translate(40, 60)">
+        <use
+          className={fr.cx('fr-artwork-decorative')}
+          xlinkHref={`${TechnicalErrorDsfr}#artwork-decorative`}
+        ></use>
+        <use
+          className={fr.cx('fr-artwork-minor')}
+          xlinkHref={`${TechnicalErrorDsfr}#artwork-minor`}
+        ></use>
+        <use
+          className={fr.cx('fr-artwork-major')}
+          xlinkHref={`${TechnicalErrorDsfr}#artwork-major`}
+        ></use>
+      </g>
+    </svg>
+  )
+}

--- a/src/components/pictogram/computer-error.svg
+++ b/src/components/pictogram/computer-error.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 32 32" enable-background="new 0 0 32 32" id="Stock_cut" version="1.1" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<desc/>
+<g>
+<path d="M29,27H3   c-1.105,0-2-0.895-2-2V7c0-1.105,0.895-2,2-2h26c1.105,0,2,0.895,2,2v18C31,26.105,30.105,27,29,27z" fill="none" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2"/>
+<rect fill="none" height="4" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" width="4" x="14" y="27"/>
+<line fill="none" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" x1="31" x2="1" y1="23" y2="23"/>
+<line fill="none" stroke="#000000" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="2" x1="9" x2="23" y1="31" y2="31"/>
+<line fill="none" stroke="#000000" stroke-miterlimit="10" stroke-width="2" x1="16" x2="16" y1="8" y2="16"/>
+<line fill="none" stroke="#000000" stroke-miterlimit="10" stroke-width="2" x1="16" x2="16" y1="18" y2="20"/>
+</g>
+</svg>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -15,6 +15,7 @@ type ImportMetaEnv = {
   VITE_TELEMETRY_DISABLED: string
   VITE_TELEMETRY_MAX_DELAY: string
   VITE_TELEMETRY_MAX_LENGTH: string
+  VITE_IS_GOV_INSTANCE: string
   BASE_URL: string
   MODE: string
   DEV: boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@codegouvfr/react-dsfr@^1.13.6":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@codegouvfr/react-dsfr/-/react-dsfr-1.17.0.tgz#f781abd40493de02d89d1b11240a4500d24b097a"
-  integrity sha512-zYluHhGRD39ckZvQFgK8hSeo76TbxPtuot+I6N66vC6XXkILvv0llbIvezkxv3xlz4J8fvq4Ou5Hngt5EWtpeg==
+"@codegouvfr/react-dsfr@^1.23.4":
+  version "1.23.4"
+  resolved "https://registry.yarnpkg.com/@codegouvfr/react-dsfr/-/react-dsfr-1.23.4.tgz#a2bd7afcf6f6d2caba362a43576c07bdf155bb1c"
+  integrity sha512-DPAKstdVaUokYGMA2zmINM3Gmi3+zKG8x4okTETDRHbXqzr+G8DjslMNffwCVWW9CUHLSA/JIeyvQQFF2fxZ0A==
   dependencies:
     tsafe "^1.8.5"
     yargs-parser "^21.1.1"
@@ -6795,16 +6795,7 @@ string-argv@^0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6871,14 +6862,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7631,16 +7615,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# 🧪 Experimental use of `react-dsfr` white-label feature

This PR introduces an **experimental implementation** of the [[white-labeling mode](https://github.com/codegouvfr/react-dsfr#white-label-mode)](https://github.com/codegouvfr/react-dsfr#white-label-mode) in `react-dsfr`. It allows displaying INSEE survey pages **without any reference to the French government** (e.g. *République Française*, Marianne logo, etc.).

## 🔧 Activation

The white-label mode can be toggled via the `VITE_IS_GOV_INSTANCE` environment variable:

```bash
VITE_IS_GOV_INSTANCE=false
```

* `true` → display full government branding (default DSFR behavior)
* `false` → display INSEE-branded version without government identity

This enables flexible deployments depending on the institutional context.

## 📸 Screenshot

Example screen:![image](https://github.com/user-attachments/assets/5b36b56c-db66-4db8-bdef-88863923c14c)
