### PR TITLE
fix: from idSU to idInterrogation in paradata

### DIFF
--- a/src/components/orchestrator/Orchestrator.test.tsx
+++ b/src/components/orchestrator/Orchestrator.test.tsx
@@ -72,7 +72,7 @@ describe('Orchestrator', () => {
     />
   )
 
-  it('sets idSU as default value', async () => {
+  it('sets idInterrogation as default value', async () => {
     const setDefaultValues = vi.fn()
 
     renderWithRouter(
@@ -90,7 +90,7 @@ describe('Orchestrator', () => {
     await waitFor(() => expect(setDefaultValues).toHaveBeenCalledOnce())
     await waitFor(() =>
       expect(setDefaultValues).toHaveBeenCalledWith({
-        idSU: 'my-service-unit-id',
+        idInterrogation: 'my-service-unit-id',
       }),
     )
   })

--- a/src/components/orchestrator/Orchestrator.tsx
+++ b/src/components/orchestrator/Orchestrator.tsx
@@ -284,7 +284,7 @@ export function Orchestrator(props: OrchestratorProps) {
   // Telemetry initialization
   useEffect(() => {
     if (!isTelemetryDisabled && mode === MODE_TYPE.COLLECT) {
-      setDefaultValues({ idSU: initialInterrogation?.id })
+      setDefaultValues({ idInterrogation: initialInterrogation?.id })
       setIsTelemetryInitialized(true)
     }
   }, [isTelemetryDisabled, mode, setDefaultValues, initialInterrogation?.id])

--- a/src/contexts/TelemetryContext.test.tsx
+++ b/src/contexts/TelemetryContext.test.tsx
@@ -46,7 +46,7 @@ describe('Telemetry context', () => {
 
     const { result } = renderHook(() => useTelemetry(), { wrapper })
 
-    const myValues = { idSU: 'abc' }
+    const myValues = { idInterrogation: 'abc' }
     result.current.setDefaultValues(myValues)
 
     expect(mock).toHaveBeenCalledWith(myValues)

--- a/src/contexts/TelemetryContext.tsx
+++ b/src/contexts/TelemetryContext.tsx
@@ -69,7 +69,7 @@ export function TelemetryProvider({
   /** Push events to telemetry API after an arbitrary number of events or a delay. */
   const pushEvents = useCallback(async (events: Array<TelemetryEvent>) => {
     if (events.length > 0) {
-      return addParadata({ idSU: events[0].idSU, events })
+      return addParadata({ idInterrogation: events[0].idInterrogation, events })
     }
   }, [])
 

--- a/src/models/telemetry.ts
+++ b/src/models/telemetry.ts
@@ -11,7 +11,7 @@ export type TelemetryEvent = DefaultParadataValues &
 
 /** Values that are set up once and added to every telemetry event */
 export type DefaultParadataValues = {
-  idSU?: string
+  idInterrogation?: string
   sid?: string
   userAgent?: string
 }


### PR DESCRIPTION
Adapt paradata object with queen-api 5.0.0 : `idSU` has been renamed into `idInterrogation`.

Nb : in queen-api, paradata object is not typed at all. It would be nice to improve it