### PR TITLE
feat: display surveyUnit label in header

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -31,11 +31,7 @@ export function Header() {
     })
   const mode = useMode()
 
-  const {
-    label: serviceTitle,
-    mainLogo,
-    interrogationIdentifier,
-  } = useMetadataStore()
+  const { label: serviceTitle, mainLogo } = useMetadataStore()
   const { isTelemetryDisabled, pushEvent, triggerBatchTelemetryCallback } =
     useTelemetry()
 
@@ -43,6 +39,7 @@ export function Header() {
    * There is an issue with this part of the code: the search type is not well narrowed with isCollectRoute. I'm waiting for a better solution.
    */
   const isCollectRoute = mode === MODE_TYPE.COLLECT
+
   const search = useSearch({ strict: false })
   const exitModal = useMemo(
     () =>
@@ -116,7 +113,7 @@ export function Header() {
                 } as const,
               ]),
         ]}
-        serviceTagline={resolveLocalizedString(interrogationIdentifier)}
+        serviceTagline={search?.surveyUnitLabel}
         serviceTitle={resolveLocalizedString(serviceTitle)}
         operatorLogo={{
           alt: resolveLocalizedStringDetailed(mainLogo.label).str,

--- a/src/components/orchestrator/Orchestrator.test.tsx
+++ b/src/components/orchestrator/Orchestrator.test.tsx
@@ -21,7 +21,6 @@ describe('Orchestrator', () => {
     label: 'my label',
     objectives: 'my objectives',
     mainLogo: { label: 'logo label', url: '' },
-    interrogationIdentifier: 'my survey id',
   }
   const source = {
     componentType: 'Questionnaire',

--- a/src/components/orchestrator/customPages/WelcomePage.test.tsx
+++ b/src/components/orchestrator/customPages/WelcomePage.test.tsx
@@ -38,7 +38,6 @@ describe('WelcomePage', () => {
             },
           ],
           mainLogo: { label: '', url: '' },
-          interrogationIdentifier: 'Id de la personne qui répond',
         }}
       />,
     )

--- a/src/models/metadata.ts
+++ b/src/models/metadata.ts
@@ -18,5 +18,4 @@ export type Metadata = {
   secondariesLogo?: Logo[]
   campaignInfo?: Contents[]
   interrogationInfo?: Contents[]
-  interrogationIdentifier: LocalizedString
 }

--- a/src/models/metadataSchema.ts
+++ b/src/models/metadataSchema.ts
@@ -39,7 +39,6 @@ export const interrogationMetadataSchema = z.object({
       }),
     )
     .optional(),
-  interrogationdentifier: z.string().optional(),
   interrogationInfo: contentsSchema.array().optional(),
   campaignInfo: contentsSchema.array().optional(),
 })

--- a/src/pages/collect/route.tsx
+++ b/src/pages/collect/route.tsx
@@ -19,6 +19,7 @@ import { CollectPage } from './CollectPage'
 
 const collectSearchParams = z.object({
   pathAssistance: z.string().optional(),
+  surveyUnitLabel: z.string().optional(),
 })
 
 export const collectPath = '/interrogations/$interrogationId'

--- a/src/pages/review/route.tsx
+++ b/src/pages/review/route.tsx
@@ -1,5 +1,6 @@
 import type { LunaticSource } from '@inseefr/lunatic'
 import { createRoute } from '@tanstack/react-router'
+import { z } from 'zod'
 
 import { getGetQuestionnaireDataQueryOptions } from '@/api/03-questionnaires'
 import {
@@ -16,6 +17,10 @@ import { convertOldPersonalization } from '@/utils/convertOldPersonalization'
 
 import { ReviewPage } from './ReviewPage'
 
+const reviewSearchParams = z.object({
+  surveyUnitLabel: z.string().optional(),
+})
+
 export const reviewPath = '/review/interrogations/$interrogationId'
 
 export const reviewRoute = createRoute({
@@ -26,6 +31,7 @@ export const reviewRoute = createRoute({
     protectedRouteLoader({
       kc_idp_hint: import.meta.env.VITE_REVIEW_IDENTITY_PROVIDER,
     }),
+  validateSearch: reviewSearchParams,
   loader: async ({
     params: { interrogationId },
     context: { queryClient },

--- a/src/stores/metadataStore.ts
+++ b/src/stores/metadataStore.ts
@@ -12,11 +12,6 @@ const defaultState: Metadata = {
     en: 'Short objective of your survey',
     sq: 'Objektivi i shkurtër i anketës tuaj',
   },
-  interrogationIdentifier: {
-    fr: 'Application de collecte internet',
-    en: 'Internet Collection Application',
-    sq: 'Aplikacioni për Mbledhjen e të Dhënave në Internet',
-  },
   mainLogo: {
     label: {
       fr: "Logo de l'insee",


### PR DESCRIPTION
In collect & review mode : handle a new optional queryParam `surveyUnitLabel` for displaying it in the Header (nothing displayed by default).

Also removed "interrogationIdentifier" in metadata since it has never been implemented and is finally replaced by this queryParam